### PR TITLE
Add support for product changes to OEP-1

### DIFF
--- a/oep-template.rst
+++ b/oep-template.rst
@@ -32,6 +32,9 @@ OEP-XXX: OEP Template
 +---------------+-------------------------------------------+
 | `Replaced-By` | <OEP number>                              |
 +---------------+-------------------------------------------+
+| `References`  | <links to any other relevant discussions  |
+|               | or relevant related materials>            |
++---------------+-------------------------------------------+
 
 Abstract
 ========

--- a/oep-template.rst
+++ b/oep-template.rst
@@ -21,7 +21,7 @@ OEP-XXX: OEP Template
 |               | Replaced>                                 |
 +---------------+-------------------------------------------+
 | Type          | <Architecture | Best Practice |           |
-|               | Process>                                  |
+|               | Process | Product Enhancement>            |
 +---------------+-------------------------------------------+
 |  Created      | <date created on, in YYYY-MM-DD format>   |
 +---------------+-------------------------------------------+
@@ -57,8 +57,8 @@ Specification
 =============
 
 The specification describes the technical details of the Architecture, Best
-Practice, or Process change proposed by the OEP. If the proposal includes a new
-API, specify its syntax and semantics.
+Practice, Process or Product Enhancement proposed by the OEP. If the proposal
+includes a new API, specify its syntax and semantics.
 
 Rationale
 =========

--- a/oeps/oep-0001.rst
+++ b/oeps/oep-0001.rst
@@ -89,11 +89,11 @@ Initial Submission
 ------------------
 
 Once the Author has asked the Open edX community whether an idea has any chance
-of acceptance, a draft OEP should be written submitted as a pull request against the
-`central OEP repository`_. To identify the draft proposal, the Author should check the
-numbered list of previous OEP pull requests and select the next available
-number. The pull request title must start with "OEP-XXX", which claims that OEP
-number for the included proposal.
+of acceptance, a draft OEP should be submitted as a pull request against the
+`central OEP repository`_. To identify the draft proposal, the Author should
+check the numbered list of previous OEP pull requests and select the next 
+available number. The pull request title must start with "OEP-XXX", which 
+claims that OEP number for the included proposal.
 
 .. _central OEP repository: http://github.com/edx/open-edx-proposals
 

--- a/oeps/oep-0001.rst
+++ b/oeps/oep-0001.rst
@@ -51,6 +51,9 @@ OEP Types
 * An **Architecture** proposal describes relationships between Open edX
   services and libraries, including their APIs and data formats.
 
+* A **Product** proposal describes a significant enhancement to the
+  functionality of the Open edX platform.
+
 Workflow
 ========
 
@@ -58,8 +61,8 @@ Workflow
   :local:
   :depth: 1
 
-Submitting an OEP
------------------
+Before Submitting an OEP
+------------------------
 
 The OEP process begins with a new idea for Open edX. It is highly recommended
 that a single OEP contain a single key proposal or new idea. Small enhancements
@@ -70,8 +73,7 @@ Each OEP must have a Author: someone who writes the OEP using the style and
 format described below, shepherds the discussions in the appropriate forums,
 and attempts to build community consensus around the idea. The OEP Author
 should first attempt to ascertain whether the idea is appropriate for an OEP.
-Posting to either the `edx-code`_ mailing list, or to ``arch@edx.org`` and
-``archexternal@edx.org`` is the best way to go about this.
+Posting to the `edx-code`_ mailing list is the best way to go about this.
 
 Vetting an idea publicly before going as far as writing an OEP is meant to save
 the potential author time. Many ideas have been brought forward for changing
@@ -83,28 +85,23 @@ sure the idea is applicable to the entire community and not just the author.
 Just because an idea sounds good to the author does not mean it will work for
 most Open edX installations.
 
+Initial Submission
+------------------
+
 Once the Author has asked the Open edX community whether an idea has any chance
-of acceptance, a draft OEP should be submitted as a pull request against the
-`central OEP repository`_. To identify the draft proposal, the Author should
-check the numbered list of previous OEP pull requests and select the next
-available number. The pull request title must start with "OEP-XXX", which
-claims that OEP number for the included proposal.
+of acceptance, a draft OEP should be written submitted as a pull request against the
+`central OEP repository`_. To identify the draft proposal, the Author should check the
+numbered list of previous OEP pull requests and select the next available
+number. The pull request title must start with "OEP-XXX", which claims that OEP
+number for the included proposal.
 
 .. _central OEP repository: http://github.com/edx/open-edx-proposals
 
-As updates are necessary, the OEP Author can update the pull request.
-
-OEPs can be reference pull requests to other Open edX repositories which
-will act as reference implementations.
-
-OEP Review & Resolution
------------------------
-
-After the Author drafts an OEP, and submits it as a pull request, they request
-an Arbiter from the edX Chief Architect. This Arbiter will be recorded in the
-"Arbiter" header on the OEP. The rest of Open edX community will be given the
-opportunity to comment on the OEP, with the Arbiter serving to keep the
-discussion on track and to evaluate when it has reached a final conclusion.
+After the Author drafts an OEP in a format in which they are comfortable, they
+request an Arbiter from the edX Chief Architect. This Arbiter will be recorded
+in the "Arbiter" header on the OEP. The rest of Open edX community will be
+given the opportunity to comment on the OEP, with the Arbiter serving to keep
+the discussion on track and to evaluate when it has reached a final conclusion.
 
 For an OEP to be accepted by the Arbiter, it must meet certain minimum
 criteria. It must be a clear and complete description of the proposed
@@ -113,6 +110,15 @@ implementation, if applicable, must pass the existing
 `Open edX Contribution Guidelines`_.
 
 .. _Open edX Contribution Guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/index.html
+
+As updates are necessary, the OEP Author or Arbiter can update the pull
+request.
+
+OEPs can be reference pull requests to other Open edX repositories which
+will act as reference implementations.
+
+OEP Review & Resolution
+-----------------------
 
 Once an OEP has been accepted by an Arbiter, it is "Under Review". Once this
 state is acheived, we recommend announcing the OEP to the community in relevant
@@ -160,7 +166,7 @@ converges to being either "Accepted" or "Rejected".
 OEP Roles
 ---------
 
-Each OEP has an Arbiter (as described in `OEP Review & Resolution`_). The
+Each OEP has an Arbiter (as described in `Initial Submission`_). The
 Arbiter will be chosen by the edX Chief Architect (currently Eddie Fagin). The
 Arbiter will be the person making the final decision on whether the OEP should
 be Accepted, and as such, the Arbiter should be knowledgeable about the
@@ -169,12 +175,13 @@ against it by the rest of the community.
 
 The Author of an OEP will never be selected as the Arbiter of that OEP.
 
-The Arbiter is also responsible for helping the Author to solicit feedback from
-the community on the OEP, and for helping to move the OEP towards a final
-decision (whether that decision is Accepted, Rejected, or Deferred). The
-Arbiter (in discussion with the Author) can merge an in-progress OEP (if it has
-reached a stage of relative stability) to allow for additional incremental
-updates.
+The Arbiter is also responsible for helping the Author move the proposal
+through the OEP process, providing technical and process expertise as needed.
+The Arbiter also assists the Author to solicit feedback from the community on
+the OEP, and for helping to move the OEP towards a final decision (whether that
+decision is Accepted, Rejected, or Deferred). The Arbiter (in discussion with 
+the Author) can merge an in-progress OEP (if it has reached a stage of relative
+stability) to allow for additional incremental updates.
 
 Finally, the Arbiter is responsible for the decision to transfer an OEP if the
 original Author has become unresponsive (as described in `Transferring OEP
@@ -289,6 +296,12 @@ ReStructuredText [8] allows for rich markup that is relatively easy to read,
 and can also be rendered into good-looking and functional HTML. OEPs are
 rendered to HTML using Sphinx. An `OEP template`_ can be found in the repo.
 
+OEPs may be discussed in a more convenient format, such as a Google Doc, if
+it is deemed most appropriate for the audience. The final OEP should be
+committed as described above with a link to the location of any discussion,
+and the ownership of the discussion document should be transferred to the edX
+Chief Architect.
+
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _OEP template: https://github.com/cpennington/open-edx-proposals/blob/master/oep-template.rst
 
@@ -326,6 +339,9 @@ described below. All other rows are required.
 | `Replaces`    | <OEP number>                              |
 +---------------+-------------------------------------------+
 | `Replaced-By` | <OEP number>                              |
++---------------+-------------------------------------------+
+| `References`  | <links to any other relevant discussions  |
+|               | or relevant related materials>            |
 +---------------+-------------------------------------------+
 
 The Author header lists the names, and optionally the email addresses, of all

--- a/oeps/oep-0001.rst
+++ b/oeps/oep-0001.rst
@@ -300,9 +300,12 @@ rendered to HTML using Sphinx. An `OEP template`_ can be found in the repo.
 
 OEPs may be discussed in a more convenient format, such as a Google Doc, if
 it is deemed appropriate for the audience and sufficiently open to comment and
-review. The final OEP should be committed as described above with a link to the
-location of any discussion, and the ownership of the discussion document should
-be transferred to the edX Chief Architect.
+review. The final OEP must be transcribed into the `reStructuredText`_-based
+template and committed to the OEP repository. The Arbiter shall be responsible
+for ensuring the proper transcription. The reviewed and accepted OEP must
+reference the location of relevant discussion, and the ownership of the
+discussion document should be transferred to the edX Chief Architect, if
+applicable.
 
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _OEP template: https://github.com/cpennington/open-edx-proposals/blob/master/oep-template.rst

--- a/oeps/oep-0001.rst
+++ b/oeps/oep-0001.rst
@@ -9,7 +9,8 @@ OEP-1: OEP Purpose and Guidelines
 +---------------+-------------------------------------------+
 | Last-Modified | 2016-08-24                                |
 +---------------+-------------------------------------------+
-| Author        | Calen Pennington <cale@edx.org>           |
+| Authors       | Calen Pennington <cale@edx.org>           |
+|               | Joel Barciauskas <joel@edx.org>           |
 +---------------+-------------------------------------------+
 | Arbiter       | Eddie Fagin <efagin@edx.org>              |
 +---------------+-------------------------------------------+
@@ -51,7 +52,7 @@ OEP Types
 * An **Architecture** proposal describes relationships between Open edX
   services and libraries, including their APIs and data formats.
 
-* A **Product** proposal describes a significant enhancement to the
+* A **Product Enhancement** proposal describes a significant enhancement to the
   functionality of the Open edX platform.
 
 Workflow
@@ -98,10 +99,11 @@ claims that OEP number for the included proposal.
 .. _central OEP repository: http://github.com/edx/open-edx-proposals
 
 After the Author drafts an OEP in a format in which they are comfortable, they
-request an Arbiter from the edX Chief Architect. This Arbiter will be recorded
-in the "Arbiter" header on the OEP. The rest of Open edX community will be
-given the opportunity to comment on the OEP, with the Arbiter serving to keep
-the discussion on track and to evaluate when it has reached a final conclusion.
+will request an Arbiter from the edX Chief Architect. This Arbiter will be
+recorded in the "Arbiter" header on the OEP. The rest of Open edX community 
+will be given the opportunity to comment on the OEP, with the Arbiter serving
+to keep the discussion on track and to evaluate when it has reached a final
+conclusion.
 
 For an OEP to be accepted by the Arbiter, it must meet certain minimum
 criteria. It must be a clear and complete description of the proposed
@@ -114,8 +116,8 @@ implementation, if applicable, must pass the existing
 As updates are necessary, the OEP Author or Arbiter can update the pull
 request.
 
-OEPs can be reference pull requests to other Open edX repositories which
-will act as reference implementations.
+OEPs can reference pull requests to other Open edX repositories which will act
+as reference implementations.
 
 OEP Review & Resolution
 -----------------------
@@ -297,10 +299,10 @@ and can also be rendered into good-looking and functional HTML. OEPs are
 rendered to HTML using Sphinx. An `OEP template`_ can be found in the repo.
 
 OEPs may be discussed in a more convenient format, such as a Google Doc, if
-it is deemed most appropriate for the audience. The final OEP should be
-committed as described above with a link to the location of any discussion,
-and the ownership of the discussion document should be transferred to the edX
-Chief Architect.
+it is deemed appropriate for the audience and sufficiently open to comment and
+review. The final OEP should be committed as described above with a link to the
+location of any discussion, and the ownership of the discussion document should
+be transferred to the edX Chief Architect.
 
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _OEP template: https://github.com/cpennington/open-edx-proposals/blob/master/oep-template.rst


### PR DESCRIPTION
The purpose of this pull request is to add support for proposing changes to the
functionality of the Open edX platform to the OEP process. Rather than
using multiple processes, I believe the OEP process can be easily
adapted to this case, particularly with some light support for less technical
forms of discussion.

Changelog:

* New "Product" proposal type
* Remove references to arch@ email address
* Created "Inital Submission" section
* Increased scope of Arbiter role to include helping with GitHub and other
  technical mechanics as needed
* Added support for Google Docs and other external forums for discussion of
  the proposal
* Added "References" field to the table as a place to put links to external
  discussions