### PR TITLE
PLAT-1084 Use edx-sphinx-theme for output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 _build
+
+# IDEs and text editors
+*~
+*.swp
+.idea/
+.project
+.pycharm_helpers/
+.pydevproject
+
+# OS X artifacts
+*.DS_Store

--- a/oep-template.rst
+++ b/oep-template.rst
@@ -113,19 +113,3 @@ Change History
 ==============
 
 A list of dated sections that describes a brief summary of each revision of the OEP.
-
-
-Copyright
-=========
-
-.. this section might need revision
-
-.. image:: https://i.creativecommons.org/l/by-sa/4.0/88x31.png
-    :alt: Creative Commons License CC-BY-SA
-    :target: http://creativecommons.org/licenses/by-sa/4.0/
-
-This work is licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License`_.
-
-.. _Creative Commons Attribution-ShareAlike 4.0 International License: https://creativecommons.org/licenses/by-sa/4.0/
-
-

--- a/oeps/conf.py
+++ b/oeps/conf.py
@@ -15,6 +15,8 @@
 import sys
 import os
 
+import edx_theme
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -29,6 +31,7 @@ import os
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'edx_theme',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
@@ -50,7 +53,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Open edX Proposals'
-author = 'edX'
+author = edx_theme.AUTHOR
+copyright = edx_theme.COPYRIGHT
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -111,7 +115,7 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'edx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -119,7 +123,7 @@ html_theme = 'alabaster'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [edx_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
@@ -228,7 +232,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'OpenedXProposals.tex', u'Open edX Proposals Documentation',
-     u'Calen Pennington', 'manual'),
+     author, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/oeps/oep-0001.rst
+++ b/oeps/oep-0001.rst
@@ -391,15 +391,3 @@ Change History
 
 * Add a definition of the *Change History* section.
 * Add a copyright notice.
-
-
-Copyright
-=========
-
-.. image:: https://i.creativecommons.org/l/by-sa/4.0/88x31.png
-    :alt: Creative Commons License CC-BY-SA
-    :target: http://creativecommons.org/licenses/by-sa/4.0/
-
-This work is licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License`_.
-
-.. _Creative Commons Attribution-ShareAlike 4.0 International License: https://creativecommons.org/licenses/by-sa/4.0/

--- a/oeps/oep-0002.rst
+++ b/oeps/oep-0002.rst
@@ -161,15 +161,3 @@ Change History
 * Original publication
 
 
-Copyright
-=========
-
-.. image:: https://i.creativecommons.org/l/by-sa/4.0/88x31.png
-    :alt: Creative Commons License CC-BY-SA
-    :target: http://creativecommons.org/licenses/by-sa/4.0/
-
-This work is licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License`_.
-
-.. _Creative Commons Attribution-ShareAlike 4.0 International License: https://creativecommons.org/licenses/by-sa/4.0/
-
-

--- a/oeps/oep-0003.rst
+++ b/oeps/oep-0003.rst
@@ -220,17 +220,3 @@ Backwards Compatibility
 
 Change History
 ==============
-
-
-Copyright
-=========
-
-.. image:: https://i.creativecommons.org/l/by-sa/4.0/88x31.png
-    :alt: Creative Commons License CC-BY-SA
-    :target: http://creativecommons.org/licenses/by-sa/4.0/
-
-This work is licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License`_.
-
-.. _Creative Commons Attribution-ShareAlike 4.0 International License: https://creativecommons.org/licenses/by-sa/4.0/
-
-

--- a/oeps/oep-0004.rst
+++ b/oeps/oep-0004.rst
@@ -165,21 +165,6 @@ N/A
 Change History
 ==============
 
-
-
-Copyright
-=========
-
-.. this section might need revision
-
-.. image:: https://i.creativecommons.org/l/by-sa/4.0/88x31.png
-    :alt: Creative Commons License CC-BY-SA
-    :target: http://creativecommons.org/licenses/by-sa/4.0/
-
-This work is licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License`_.
-
-.. _Creative Commons Attribution-ShareAlike 4.0 International License: https://creativecommons.org/licenses/by-sa/4.0/
-
 .. rubric:: Footnotes
 
 .. [#rfc6749] For more information on OAuth2, please see the `OAuth2 specification <https://tools.ietf.org/html/rfc6749>`_.

--- a/oeps/oep-0005.rst
+++ b/oeps/oep-0005.rst
@@ -235,22 +235,6 @@ will need modification to fully meet the specifications of this OEP.
 Change History
 ==============
 
-
-Copyright
-=========
-
-.. this section might need revision
-
-.. image:: https://i.creativecommons.org/l/by-sa/4.0/88x31.png
-    :alt: Creative Commons License CC-BY-SA
-    :target: http://creativecommons.org/licenses/by-sa/4.0/
-
-This work is licensed under a `Creative Commons Attribution-ShareAlike 4.0
-International License`_.
-
-.. _Creative Commons Attribution-ShareAlike 4.0 International License: https://creativecommons.org/licenses/by-sa/4.0/
-
-
 .. _.dockerignore: https://docs.docker.com/engine/reference/builder/#/dockerignore-file
 .. _.gitignore: https://git-scm.com/docs/gitignore
 .. _Django: https://www.djangoproject.com/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+edx-sphinx-theme
 sphinx


### PR DESCRIPTION
Use the new edx-sphinx-theme package for the output, and remove the explicit copyright footer from each page which is now put there by the theme.  (This will need to be done for the new OEPs already created in pending PRs too.)  Also flesh out the .gitignore file with a few IDE and editor artifacts, etc.

Before merging, we should make sure that the Read the Docs project is configured to build in a virtualenv and install the dependencies from requirements.txt.