### PR TITLE
Add a "Not Applicable" state to OEP-2

### DIFF
--- a/oeps/oep-0002.rst
+++ b/oeps/oep-0002.rst
@@ -64,9 +64,15 @@ following fields:
     ``oep-n``). Each value would be one of ``True``, ``False``, or a
     reason dictionary. ``True`` and ``False`` would indicate accordance (or
     lack thereof) with the specified OEP. A reason dictionary
-    must have ``state`` and ``reason`` keys. The ``state`` key is a boolean,
-    and ``reason`` is a string that should explain why it's ok that the
-    ``state`` is ``False`` (this will be displayed in reporting tools).
+    must have a ``state`` key. The ``state`` key can have a value of ``True``,
+    ``False`` or ``Not Applicable``. If the ``state`` is ``False`` the reason
+    dictionary must also include a ``reason`` key. The ``reason`` is a string
+    that should explain why it's ok that the ``state`` is ``False``
+    (this will be displayed in reporting tools). A ``state`` value of
+    ``Not Applicable`` indicates the OEP will never be applicable to this
+    repository. For example: an OEP that defines a best practices for Javascript
+    testing would be marked as ``Not Applicable`` in a python command line
+    tool's repository.
 
     If an OEP isn't listed in the ``oeps`` dictionary, then it is assumed to be
     ``False``, unless the reporting tool can auto-detect accordance.

--- a/oeps/oep-0002.rst
+++ b/oeps/oep-0002.rst
@@ -61,21 +61,22 @@ following fields:
 
 ``oeps``: dictionary (optional)
     A list of keys corresponding to Best Practice OEPs (in the format
-    ``oep-n``). Each value would be one of ``True``, ``False``, or a
-    reason dictionary. ``True`` and ``False`` would indicate accordance (or
-    lack thereof) with the specified OEP. A reason dictionary
-    must have a ``state`` key. The ``state`` key can have a value of ``True``,
-    ``False`` or ``Not Applicable``. If the ``state`` is ``False`` the reason
-    dictionary must also include a ``reason`` key. The ``reason`` is a string
-    that should explain why it's ok that the ``state`` is ``False``
-    (this will be displayed in reporting tools). A ``state`` value of
-    ``Not Applicable`` indicates the OEP will never be applicable to this
-    repository. For example: an OEP that defines a best practices for Javascript
-    testing would be marked as ``Not Applicable`` in a python command line
-    tool's repository.
-
-    If an OEP isn't listed in the ``oeps`` dictionary, then it is assumed to be
-    ``False``, unless the reporting tool can auto-detect accordance.
+    ``oep-n``). Each value would be one of ``True``, ``False``, or a reason
+    dictionary. ``True`` and ``False`` would indicate accordance (or lack
+    thereof) with the specified OEP. A reason dictionary provides more detailed
+    information. It can contain a boolean ``state``, a boolean ``applicable``,
+    and a string ``reason``. If the OEP is not applicable to this repository,
+    the reason dictionary can simply contain a single value of ``False`` for the
+    ``applicable`` key. A ``False`` value for ``applicable`` indicates the OEP
+    will never be applicable to this repository. For example: an OEP that
+    defines a best practices for Javascript testing would be marked as not
+    applicable in a python command line tool's repository. If the ``state`` is
+    ``False`` a ``reason`` value must be included that explains why. If the
+    ``state`` is ``True`` or ``applicable`` is ``False`` the ``reason`` can
+    optionally provide more information. The ``reason`` value will be displayed
+    in reporting tools. If an OEP isn't listed in the ``oeps`` dictionary, then
+    it is assumed to be ``False``, unless the reporting tool can auto-detect
+    accordance.
 
 ``track-pulls``: boolean (optional)
 
@@ -111,6 +112,13 @@ For example, in the `edx-platform`_ repo, the file might look like:
         oep-42:
             state: False
             reason: This OEP doesn't actually exist
+        oep-2:
+            state: True  # no reason is required since this is True
+        oep-100:
+            applicable: False  # state is not required since the OEP is not applicable
+            reason: This OEP contains best practices for C++ which is not used in edx-platform
+        oep-101:
+            applicable: False  # reason is not required since it's almost always just a redundant statement about it not being applicable
 
 
 Rationale
@@ -134,6 +142,11 @@ The design of the ``oeps`` dictionary was guided by a couple of use cases:
 
 Change History
 ==============
+
+2016-01-10
+----------
+
+* Support the ``applicable`` key in the reason dictionary.
 
 2016-10-13
 ----------


### PR DESCRIPTION
When updating [openedx.yaml](https://github.com/edx/edx-analytics-pipeline/blob/5b3a6db1e466a18d67cc74c0a4c98e2c3906290d/openedx.yaml) for edx-analytics-pipeline as part of the OEP-5 adoption work. I discovered that many OEPs don't really apply to the data pipeline. However, there was no way for me to mark those OEPs as "not applicable" so any automated reports would just assume that this repo was not compliant.

A reasonable argument could also be made for just setting the `state` to `True` in those cases, but I think I prefer the explicit third state.

FYI @cpennington 