### PR TITLE
Make README link to docs less confusing.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,14 +9,6 @@ choice. OEPs are not the only way for a change to be made to Open edX, however,
 the goal is to create a collection of OEP documents as a repository or knowledge
 archive of large and broadly relevant choices made for the platform.
 
-View the published OEPs on ReadTheDocs: `OEP Index`_
+View the published list of `Open edX Proposals (OEPs)`_ on ReadTheDocs.
 
-.. _OEP Index: https://open-edx-proposals.readthedocs.io
-
-Note
-----
-
-    This is the listing of all Open edX Proposals (OEPs). If you are looking for
-    OER Enhancement Proposals, please visit `oep.readthedocs.io`_.
-
-.. _oep.readthedocs.io: https://oep.readthedocs.io
+.. _Open edX Proposals (OEPs): https://open-edx-proposals.readthedocs.io


### PR DESCRIPTION
I clicked on the wrong link to the wrong docs.  I can't imagine I'd be the last person to make that mistake.  I think it would be better to make the link clear that it isn't for OERs, and let someone find that if they need to.