### PR TITLE
OEP-21: mark removal date as a beginning, not an end

### DIFF
--- a/oeps/oep-0021-proc-deprecation.rst
+++ b/oeps/oep-0021-proc-deprecation.rst
@@ -216,7 +216,7 @@ engineering organization (`edx-code example`_):
         Hi there,
 
         We plan to deprecate and remove <*Short description of the technology*>.
-        We are targeting removal by <*Target Removal Date*>.
+        We are targeting removal after <*Target Removal Date*>.
 
         Please read https://openedx.atlassian.net/browse/<*DEPR-Number*> for
         more information and to post any questions/comments. The proposed
@@ -235,7 +235,7 @@ Post the following in the #open-edx-proposals and #general `openedx slack`_ chan
 
     *Removal of <*Technology Name*>:*
     We plan to deprecate and remove <*Short description of the technology*>.
-    We are targeting removal by <*Target Removal Date*>.
+    We are targeting removal after <*Target Removal Date*>.
 
     Please read https://openedx.atlassian.net/browse/<*DEPR-Number*> for
     more information and to post any questions/comments. The proposed


### PR DESCRIPTION
During discussions about OEP-21, we were talking like we wanted the removal date to be a target by which everyone should migrate away, and after which we'll be safe to actually remove the code (rather than a deadline for us to remove the code).

This PR makes that a bit clearer in the template language.