### PR TITLE
Remove gemnasium step from OEP-0014

### DIFF
--- a/oeps/oep-0014-proc-archive-repos.rst
+++ b/oeps/oep-0014-proc-archive-repos.rst
@@ -93,14 +93,6 @@ Archive Steps
 3. Create an IT help ticket to update the description of the repository to
    begin with ``[ARCHIVED]``.
 
-4. Create a DevOps ticket to change the status of the repo to "non-monitored"
-   in Gemnasium, and to remove any integration or webhooks that DevOps may be
-   maintaining.
-
-In the future, the step of changing the monitored status of a repository in
-Gemnasium could be automated using Gemansium APIs and keying off of the
-``archived`` value in openedx.yaml.
-
 README Archive Statement
 ------------------------
 Include this statement in the README.rst file:


### PR DESCRIPTION
I was going through these docs to archive a tools repo and noticed it still references Gemnasium in the steps. Gemnasium is no longer an active service, so we should remove that from the docs (https://docs.gitlab.com/ee/user/project/import/gemnasium.html).

It should probably stay in the motivation/ rejected alternatives, as it was still a contributing factor to this OEP.