### PR TITLE
Update OEPs for announcements and switch ownership.

### DIFF
--- a/oeps/oep-0014-proc-archive-repos.rst
+++ b/oeps/oep-0014-proc-archive-repos.rst
@@ -68,14 +68,14 @@ Transfer to New Owner if Interest
 First, if the repository is public, and a part of Open edX releases, follow
 these steps to see if anyone would like to take ownership of it:
 
-1. Send an email to edx-code@googlegroups.com announcing that the repository
+1. Post a notice to `Open edX Deprecation Announcements`_ announcing that the repository
    will be archived, and inquiring if anyone would like to take ownership of
    the repo. If there are no responses after 2 work days, skip to `Archive
    Steps`_.
 
 2. If someone does wish to take ownership of the repository, email the internal
    edX developers mailing list to see if there are any objections. If there are
-   no objections after 2 work days, post to edx-code@googlegroups.com that the
+   no objections after 2 work days, post to `Open edX Deprecation Announcements`_ that the
    transfer will take place.
 
 3. Create an IT help ticket for the repository to be transferred to the new
@@ -84,6 +84,8 @@ these steps to see if anyone would like to take ownership of it:
 4. Once the transfer has occurred, create a fork of the transferred repository
    into the `edx organization`_ and follow the `Archive Steps`_ below for the
    forked repo.
+
+.. _Open edX Deprecation Announcements: https://discuss.openedx.org/c/announcements/deprecation
 
 
 Archive Steps

--- a/oeps/oep-0021-proc-deprecation.rst
+++ b/oeps/oep-0021-proc-deprecation.rst
@@ -11,8 +11,9 @@ OEP-21: Deprecation and Removal
 +-----------------+--------------------------------------------------------+
 | Authors         | Greg Sham <gsham@edx.org>,                             |
 |                 | Nimisha Asthagiri <nimisha@edx.org>                    |
+|                 | Diana Huang <dkh@edx.org>                              |
 +-----------------+--------------------------------------------------------+
-| Arbiter         | Diana Huang <dhuang@edx.org>                           |
+| Arbiter         | Matt Tuchfarber <mtuchfarber@edx.org>                  |
 +-----------------+--------------------------------------------------------+
 | Status          | Accepted                                               |
 +-----------------+--------------------------------------------------------+
@@ -206,13 +207,10 @@ Announce
 Announce your proposal to deprecate and remove to the following communication
 channels.
 
-To edx-code
-^^^^^^^^^^^
+To the Open edX Discourse
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Send an email to edx-code_ using the following template, bcc-ing your own
-engineering organization (`edx-code example`_):
-
-    To: edx-code@googlegroups.com
+Post a message to `Open edX Discourse Deprecation Announcements`_, using the following template:
 
     Subject: Deprecation/Removal: <*Technology Name*> <*DEPR-Number*>
 
@@ -229,8 +227,8 @@ engineering organization (`edx-code example`_):
         Thanks,
         <*Your name*>
 
-.. _edx-code: https://groups.google.com/forum/#!forum/edx-code
-.. _edx-code example: https://groups.google.com/d/msg/edx-code/779kAKas2Yw/jU7vGHu8CgAJ
+
+.. _Open edX Discourse Deprecation Announcements: https://discuss.openedx.org/c/announcements/deprecation
 
 To openedx.slack.com
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
These are mostly minor updates to these OEPs to point to the discourse forum instead of edx-code, but I am also switching over the role of arbiter on OEP-0021 to @tuchfarber .