### PR TITLE
Tweak the OEP templates

### DIFF
--- a/oeps/oep-templates/adr-based-template.rst
+++ b/oeps/oep-templates/adr-based-template.rst
@@ -27,7 +27,7 @@ OEP-XXXX: OEP Template
 +-----------------+--------------------------------------------------------+
 | Created         | <date created on, in YYYY-MM-DD format>                |
 +-----------------+--------------------------------------------------------+
-| `Review Period` | <start - target end dates for review>                  |
+| Review Period   | <start - target end dates for review>                  |
 +-----------------+--------------------------------------------------------+
 
 Context

--- a/oeps/oep-templates/adr-based-template.rst
+++ b/oeps/oep-templates/adr-based-template.rst
@@ -4,31 +4,31 @@ OEP-XXXX: OEP Template
 
 .. This OEP template is based on Nygard's Architecture Decision Records.
 
-+-----------------+--------------------------------------------------------+
-| OEP             | :doc:`OEP-XXXX </oeps/oep-XXXX-YYYY-ZZZZ>`             |
-|                 |                                                        |
-|                 | * <XXXX is the next available OEP number>              |
-|                 | * <YYYY is the abbreviated Type: proc | bp | arch>     |
-|                 | * <ZZZZ is a brief (< 5 words) version of the title>   |
-+-----------------+--------------------------------------------------------+
-| Title           | <OEP title>                                            |
-+-----------------+--------------------------------------------------------+
-| Last Modified   | <date string, in YYYY-MM-DD format>                    |
-+-----------------+--------------------------------------------------------+
-| Authors         | <list of authors' real names and                       |
-|                 | optionally, email addresses>                           |
-+-----------------+--------------------------------------------------------+
-| Arbiter         | <Arbiter's real name and email address>                |
-+-----------------+--------------------------------------------------------+
-| Status          | <Draft | Under Review | Deferred | Accepted |          |
-|                 | Rejected | Withdrawn | Final | Replaced>               |
-+-----------------+--------------------------------------------------------+
-| Type            | <Architecture | Best Practice | Process>               |
-+-----------------+--------------------------------------------------------+
-| Created         | <date created on, in YYYY-MM-DD format>                |
-+-----------------+--------------------------------------------------------+
-| Review Period   | <start - target end dates for review>                  |
-+-----------------+--------------------------------------------------------+
+.. list-table::
+   :widths: 25 75
+
+   * - OEP
+     - :doc:`OEP-XXXX </oeps/oep-XXXX-YYYY-ZZZZ>`
+
+       * <XXXX is the next available OEP number>
+       * <YYYY is the abbreviated Type: proc | bp | arch>
+       * <ZZZZ is a brief (< 5 words) version of the title>
+   * - Title
+     - <OEP title>
+   * - Last Modified
+     - <date string, in YYYY-MM-DD format>
+   * - Authors
+     - <list of authors' real names and optionally, email addresses>
+   * - Arbiter
+     - <Arbiter's real name and email address>
+   * - Status
+     - <Draft | Under Review | Deferred | Accepted | Rejected | Withdrawn | Final | Replaced>
+   * - Type
+     - <Architecture | Best Practice | Process>
+   * - Created
+     - <date created on, in YYYY-MM-DD format>
+   * - Review Period
+     - <start - target end dates for review>
 
 Context
 -------

--- a/oeps/oep-templates/external-link-template.rst
+++ b/oeps/oep-templates/external-link-template.rst
@@ -27,7 +27,7 @@ OEP-XXXX: OEP Template
 +-----------------+--------------------------------------------------------+
 | Created         | <date created on, in YYYY-MM-DD format>                |
 +-----------------+--------------------------------------------------------+
-| `Review Period` | <start - target end dates for review>                  |
+| Review Period   | <start - target end dates for review>                  |
 +-----------------+--------------------------------------------------------+
 
 Abstract
@@ -43,11 +43,11 @@ List links to the external location(s) where the technical design and discussion
 are actually captured and stored.  For example, in:
 
 * a wiki in the `Architecture Notes and Thoughts space in Confluence`_
-* a Discourse discussion on `ed Xchange`_
+* a Discourse discussion on `discuss.openedx.org`_
 * a public Google doc
 
 .. _Open edX Architecture space in Confluence: https://openedx.atlassian.net/wiki/spaces/AC/pages/65667085/Architecture+Notes+and+Thoughts
-.. _ed Xchange: https://edxchange.opencraft.com/
+.. _discuss.openedx.org: https://discuss.openedx.org
 
 Decisions
 ---------

--- a/oeps/oep-templates/external-link-template.rst
+++ b/oeps/oep-templates/external-link-template.rst
@@ -4,31 +4,31 @@ OEP-XXXX: OEP Template
 
 .. This OEP template is recommended when content is externally linked.
 
-+-----------------+--------------------------------------------------------+
-| OEP             | :doc:`OEP-XXXX </oeps/oep-XXXX-YYYY-ZZZZ>`             |
-|                 |                                                        |
-|                 | * <XXXX is the next available OEP number>              |
-|                 | * <YYYY is the abbreviated Type: proc | bp | arch>     |
-|                 | * <ZZZZ is a brief (< 5 words) version of the title>   |
-+-----------------+--------------------------------------------------------+
-| Title           | <OEP title>                                            |
-+-----------------+--------------------------------------------------------+
-| Last Modified   | <date string, in YYYY-MM-DD format>                    |
-+-----------------+--------------------------------------------------------+
-| Authors         | <list of authors' real names and                       |
-|                 | optionally, email addresses>                           |
-+-----------------+--------------------------------------------------------+
-| Arbiter         | <Arbiter's real name and email address>                |
-+-----------------+--------------------------------------------------------+
-| Status          | <Draft | Under Review | Deferred | Accepted |          |
-|                 | Rejected | Withdrawn | Final | Replaced>               |
-+-----------------+--------------------------------------------------------+
-| Type            | <Architecture | Best Practice | Process>               |
-+-----------------+--------------------------------------------------------+
-| Created         | <date created on, in YYYY-MM-DD format>                |
-+-----------------+--------------------------------------------------------+
-| Review Period   | <start - target end dates for review>                  |
-+-----------------+--------------------------------------------------------+
+.. list-table::
+   :widths: 25 75
+
+   * - OEP
+     - :doc:`OEP-XXXX </oeps/oep-XXXX-YYYY-ZZZZ>`
+
+       * <XXXX is the next available OEP number>
+       * <YYYY is the abbreviated Type: proc | bp | arch>
+       * <ZZZZ is a brief (< 5 words) version of the title>
+   * - Title
+     - <OEP title>
+   * - Last Modified
+     - <date string, in YYYY-MM-DD format>
+   * - Authors
+     - <list of authors' real names and optionally, email addresses>
+   * - Arbiter
+     - <Arbiter's real name and email address>
+   * - Status
+     - <Draft | Under Review | Deferred | Accepted | Rejected | Withdrawn | Final | Replaced>
+   * - Type
+     - <Architecture | Best Practice | Process>
+   * - Created
+     - <date created on, in YYYY-MM-DD format>
+   * - Review Period
+     - <start - target end dates for review>
 
 Abstract
 --------

--- a/oeps/oep-templates/pep-based-template.rst
+++ b/oeps/oep-templates/pep-based-template.rst
@@ -27,12 +27,12 @@ OEP-XXXX: OEP Template
 +-----------------+--------------------------------------------------------+
 | Created         | <date created on, in YYYY-MM-DD format>                |
 +-----------------+--------------------------------------------------------+
-| `Review Period` | <start - target end dates for review>                  |
+| Review Period   | <start - target end dates for review>                  |
 +-----------------+--------------------------------------------------------+
-| `Resolution`    | <links to any discussions where the final              |
+| Resolution      | <links to any discussions where the final              |
 |                 | status was decided>                                    |
 +-----------------+--------------------------------------------------------+
-| `References`    | <links to any other relevant discussions               |
+| References      | <links to any other relevant discussions               |
 |                 | or relevant related materials>                         |
 +-----------------+--------------------------------------------------------+
 
@@ -45,10 +45,10 @@ this Open edX proposal (OEP) addresses.
 Motivation
 ==========
 
-The motivation is critical for OEPs that will change Open edX. Explain why the
-existing architecture or process is inadequate to address the problem that the
-OEP solves, or why adopting the best practice would significantly improve Open
-edX.
+The motivation is critical for OEPs that will change any part of the Open edX
+ecosystem. Explain why the existing architecture or process is inadequate to
+address the problem that the OEP solves, or why adopting the best practice
+would significantly improve the Open edX world.
 
 Specification
 =============

--- a/oeps/oep-templates/pep-based-template.rst
+++ b/oeps/oep-templates/pep-based-template.rst
@@ -4,37 +4,35 @@ OEP-XXXX: OEP Template
 
 .. This OEP template is based on Python's PEP standard.
 
-+-----------------+--------------------------------------------------------+
-| OEP             | :doc:`OEP-XXXX </oeps/oep-XXXX-YYYY-ZZZZ>`             |
-|                 |                                                        |
-|                 | * <XXXX is the next available OEP number>              |
-|                 | * <YYYY is the abbreviated Type: proc | bp | arch>     |
-|                 | * <ZZZZ is a brief (< 5 words) version of the title>   |
-+-----------------+--------------------------------------------------------+
-| Title           | <OEP title>                                            |
-+-----------------+--------------------------------------------------------+
-| Last Modified   | <date string, in YYYY-MM-DD format>                    |
-+-----------------+--------------------------------------------------------+
-| Authors         | <list of authors' real names and                       |
-|                 | optionally, email addresses>                           |
-+-----------------+--------------------------------------------------------+
-| Arbiter         | <Arbiter's real name and email address>                |
-+-----------------+--------------------------------------------------------+
-| Status          | <Draft | Under Review | Deferred | Accepted |          |
-|                 | Rejected | Withdrawn | Final | Replaced>               |
-+-----------------+--------------------------------------------------------+
-| Type            | <Architecture | Best Practice | Process>               |
-+-----------------+--------------------------------------------------------+
-| Created         | <date created on, in YYYY-MM-DD format>                |
-+-----------------+--------------------------------------------------------+
-| Review Period   | <start - target end dates for review>                  |
-+-----------------+--------------------------------------------------------+
-| Resolution      | <links to any discussions where the final              |
-|                 | status was decided>                                    |
-+-----------------+--------------------------------------------------------+
-| References      | <links to any other relevant discussions               |
-|                 | or relevant related materials>                         |
-+-----------------+--------------------------------------------------------+
+.. list-table::
+   :widths: 25 75
+
+   * - OEP
+     - :doc:`OEP-XXXX </oeps/oep-XXXX-YYYY-ZZZZ>`
+
+       * <XXXX is the next available OEP number>
+       * <YYYY is the abbreviated Type: proc | bp | arch>
+       * <ZZZZ is a brief (< 5 words) version of the title>
+   * - Title
+     - <OEP title>
+   * - Last Modified
+     - <date string, in YYYY-MM-DD format>
+   * - Authors
+     - <list of authors' real names and optionally, email addresses>
+   * - Arbiter
+     - <Arbiter's real name and email address>
+   * - Status
+     - <Draft | Under Review | Deferred | Accepted | Rejected | Withdrawn | Final | Replaced>
+   * - Type
+     - <Architecture | Best Practice | Process>
+   * - Created
+     - <date created on, in YYYY-MM-DD format>
+   * - Review Period
+     - <start - target end dates for review>
+   * - Resolution
+     - <links to any discussions where the final status was decided>
+   * - References
+     - <links to any other relevant discussions or relevant related materials>
 
 Abstract
 ========


### PR DESCRIPTION
- No reason to italicize some of the table sections

- Use the "Open edX" trademark correctly

- Link to the latest Discourse instance