### PR TITLE
Add a horror tale when dead code is not removed

### DIFF
--- a/oeps/oep-0021-proc-deprecation.rst
+++ b/oeps/oep-0021-proc-deprecation.rst
@@ -56,7 +56,7 @@ learned the benefits of investing in code removal:
   down by zombie code. [OREILLY]_
 
 * There is a danger that someone inadvertently involves the 'dormant' code and
-  introduces bugs. [SO]_
+  introduces bugs. [SO]_ [SEC]_
 
 * Dead code makes the runtime footprint larger than it needs to be. [INFOQ]_
 
@@ -344,4 +344,5 @@ References
 
 .. [OREILLY] https://www.oreilly.com/library/view/becoming-a-better/9781491905562/ch04.html
 .. [SO] https://stackoverflow.com/a/15700228
+.. [SEC] https://www.sec.gov/litigation/admin/2013/34-70694.pdf
 .. [INFOQ] https://www.infoq.com/news/2017/02/dead-code


### PR DESCRIPTION
In the context of dead code, feature toggles could hide old code that if active could carry on significant damage.

Here's a reference to an U.S. Securities and Exchange Commission act where they order the cease and desist to a company that lost more than 400 million in trading transactions due to a repurposed "flag".

I believe this fits here, rather than in OEP-17, because this OEP-21 is somehow a detailed expansion of the "Removal" section in OEP-17 and most importantly, this OEP-21 includes a broader solution to mitigate the risk. The horror tale may also apply to configurations options and not necessarily toggles.