### PR TITLE
OEP-41: Asynchronous Server Event Message Format

### DIFF
--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -16,7 +16,7 @@ OEP-41: Asynchronous Server Event Message Format
    * - Arbiter
      - Christopher Pappas <cpappas@edx.org>
    * - Status
-     - Draft
+     - Accepted
    * - Type
      - Architecture
    * - Created
@@ -24,9 +24,7 @@ OEP-41: Asynchronous Server Event Message Format
    * - Review Period
      - 2020-08-17
    * - Resolution
-     - ?
-   * - References
-     - ?
+     - Accepted
 
 --------
 Abstract
@@ -120,10 +118,12 @@ example:
 
   {
     "id": "b3b3981e-7544-11ea-b663-acde48001122",
-    "source": "https://discovery.edx.org/events"
+    "type": "org.openedx.catalog.course.created.v1",
     "specversion": "1.0",
     "time": "2020-02-23T09:00:00Z",
-    "type": "org.openedx.catalog.course.created.v1"
+    "source": "/openedx/discovery/web",
+    "sourcehost": "edx.devstack.lms",
+    "minorversion": 2,
     "data": {
         // message specific payload here
     }

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -151,10 +151,7 @@ string using Python's default behavior: lowercase and and dash-separated.
 `source <https://github.com/cloudevents/spec/blob/master/spec.md#source-1>`_
 -----------------------------------------------------------------------------
 
-Example:
 
-If it is being hosted under a different domain, is the source expected to be
-different?
 
 
 `specversion <https://github.com/cloudevents/spec/blob/master/spec.md#specversion>`_
@@ -255,6 +252,8 @@ majority of the time, but some events might have ``text/xml``.
 `time <https://github.com/cloudevents/spec/blob/master/spec.md#time>`_
 ----------------------------------------------------------------------
 
+Example: ``"2020-02-23T09:00:00Z"``
+
 Timestamp that the event occurred, in UTC using `RFC 3339
 <https://tools.ietf.org/html/rfc3339>`_. If this event was sent because we
 created a new row in the database, we should pull this ``time`` directly from
@@ -277,7 +276,7 @@ A callback is when you create a message with an ID or URL that you expect the
 consumer to make a synchronous call to when it receives the message. This is
 commonly used when an event represents some change that is too large to
 practically fit into the 64K message. For instance, we currently emit a generic
-"course_published" Django signal whenever data is published in Studio, leading
+``course_published`` Django signal whenever data is published in Studio, leading
 to a cascade of calls from various apps to the ModuleStore in order to extract
 the content data that they need.
 
@@ -298,7 +297,7 @@ load that my service is placing on the REST endpoint serving this user
 information. Is that safe? Who knows?
 
 One thing to consider is whether we can emit multiple events that better target
-specific consumer use cases. Let's take the "course_published" event as an
+specific consumer use cases. Let's take the ``course_published`` event as an
 example. Some listeners only care about schedule changes, because they have to
 account for when a course starts and ends. Search indexing really only wants to
 know the exact bit of content that was modified so that it can update that text.

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -140,9 +140,10 @@ considered optional in the CloudEvents spec).
 `dataschema <https://github.com/cloudevents/spec/blob/master/spec.md#dataschema>`_
 ----------------------------------------------------------------------------------
 
-Example:
+Example: ???
 
-
+WIP: This would link to documentation? Fill this out after we flesh out that
+portion of this OEP.
 
 
 `id <https://github.com/cloudevents/spec/blob/master/spec.md#id>`_
@@ -159,10 +160,12 @@ string using Python's default behavior: lowercase and and dash-separated.
 `source <https://github.com/cloudevents/spec/blob/master/spec.md#source-1>`_
 -----------------------------------------------------------------------------
 
-Example:
+Example: ``"https://openedx.org/events/catalog"``
 
-
-
+WIP: It's required that this field exist and recommended that it be an absolute
+URI. Use an openedx.org domain? Should there be extra information to indicate
+things like the site it comes from (in the whitelabel sense?). Or have that info
+in the data section?
 
 
 `specversion <https://github.com/cloudevents/spec/blob/master/spec.md#specversion>`_
@@ -289,6 +292,16 @@ actions. Do call ``datetime.now()`` if the event happens and has no
 corresponding database changes. If you are sending out multiple event messages
 describing the same occurance (e.g. a version 1 and version 2 of an event), they
 should have the *exact* same timestamp.
+
+Payload Metadata
+================
+
+The ``data`` attribute contains the application-specific message data.
+
+WIP: Do we require a common metadata header everywhere? In which case, we
+wouldn't be able to use other content types, which is probably fine? Need
+minor version info here, plus maybe site information (e.g. white label?). Some
+kind of global context information?
 
 
 Message Content Data Guidelines

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -367,6 +367,10 @@ event when a catalog entry for a course is created, while Studio
 first authored there. These are similar, related events, but they are not the
 same event type.
 
+To help prevent naming collisions, the set of messages will be centralized into
+a separate repository (or possibly a separate repository per logical subdomain).
+The details of this would be worked out in a follow-on OEP.
+
 
 Avoid Callbacks
 ---------------

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -118,7 +118,7 @@ example:
 
   {
     "id": "b3b3981e-7544-11ea-b663-acde48001122",
-    "source": "???"
+    "source": "https://discovery.edx.org/events"
     "specversion": "1.0",
     "time": "2020-02-23T09:00:00Z",
     "type": "org.openedx.catalog.course.created.v1"
@@ -160,13 +160,10 @@ string using Python's default behavior: lowercase and and dash-separated.
 `source <https://github.com/cloudevents/spec/blob/master/spec.md#source-1>`_
 -----------------------------------------------------------------------------
 
-Example: ``"https://openedx.org/events/catalog"``
+Example: ``"https://courses.edx.org/events"``
 
-WIP: It's required that this field exist and recommended that it be an absolute
-URI. Use an openedx.org domain? Should there be extra information to indicate
-things like the site it comes from (in the whitelabel sense?). Or have that info
-in the data section?
-
+This is an absolute URI that represents the URL of the server emitting the
+event. It does not have
 
 `specversion <https://github.com/cloudevents/spec/blob/master/spec.md#specversion>`_
 ------------------------------------------------------------------------------------
@@ -186,6 +183,10 @@ describing the type of event, but recommends that it be prefixed with a
 reverse-DNS name for namespacing purposes. We will use a period-separated
 hierarchical name comprising with the format ``{Reverse DNS}-{Architecture
 Domain}-{Subject}-{Action}-{Major Version}``.
+
+``version``
+-----------
+
 
 
 Reverse DNS
@@ -277,6 +278,19 @@ format of ``data`` attribute. It should be ``application/json`` the vast
 majority of the time, but some events might have ``text/xml``.
 
 
+``minorversion``
+----------------
+
+Example: ``2``
+
+This is the one extension attribute we would be introducing to CloudEvents and
+represents a minor version in semver reckoning, meaning that it increments when
+we have made backwards compatible additions to the message payload in the
+``data`` attribute. Values can only be integers. The initial value for
+``minorversion`` should be ``0``. There is no corresponding ``majorversion``
+because that information is encoded into the message type.
+
+
 `time <https://github.com/cloudevents/spec/blob/master/spec.md#time>`_
 ----------------------------------------------------------------------
 
@@ -293,15 +307,6 @@ corresponding database changes. If you are sending out multiple event messages
 describing the same occurance (e.g. a version 1 and version 2 of an event), they
 should have the *exact* same timestamp.
 
-Payload Metadata
-================
-
-The ``data`` attribute contains the application-specific message data.
-
-WIP: Do we require a common metadata header everywhere? In which case, we
-wouldn't be able to use other content types, which is probably fine? Need
-minor version info here, plus maybe site information (e.g. white label?). Some
-kind of global context information?
 
 
 Message Content Data Guidelines

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -64,7 +64,7 @@ Motivation
 Open edX has multiple services that need to copy data or take specific actions
 when certain events occur in other services. For example:
 
-* The start date of a course exists in both the Catalog domain represented by
+* The start date of a course exists in both the Catalog subdomain represented by
   the course-discovery service, as well as in the LMS, where its value is used
   to help determine whether an enrolled student will have access to the content.
 * Other services often have a user table, with data replicated from the LMS
@@ -194,7 +194,7 @@ services that are part of the standard distribution of Open edX should use
 application, and "worker" will be used for events emitted by asynchronous tasks
 such as celery workers.
 
-Message clients should avoid interpreting this value or make switching logic
+Message clients should avoid interpreting this value or making switching logic
 based on where a message is coming from. These values can change without warning
 as services are split, consolidated, renamed, and refactored. It is also
 possible that the source of an event will be moved to a third party system that
@@ -254,9 +254,9 @@ The next part of the ``type`` hierarchy is the Subdomain. Examples of this are:
 * credentials
 * learning
 
-It is the expectation that there are relatively few domains, and that they will
-roughly match deployed services. Domain names should be lower cased and use
-underscores if they are more than one word.
+It is the expectation that there are relatively few subdomains, and that they
+will roughly match deployed services. Subdomain names should be lower cased and
+use underscores if they are more than one word.
 
 Subject
 ~~~~~~~
@@ -267,17 +267,17 @@ The name of an entity that the event applies to. Examples might be ``course``,
 ``student``, ``enrollment``, ``order``, etc. Subjects may be namespaced, so
 ``special_exam.proctored.allowance`` could be a subject.
 
-A subject should always mean the same thing within a Domain, but can mean
-different things across domains. For instance, what the LMS (``learning``
-domain) calls a ``course`` might map to what the ``catalog`` domain would call a
-``course_run``. We should try to be consistent where possible, but each domain
-ultimately gets to decide what its terms mean, and we should be careful when
-translating a concept from one domain to another. For instance, the
-``content_authoring`` and ``learning`` domains might both have a concept of a
-"due date" for an assignment. But while the ``content_authoring`` due date is
-determined only by the content author, the ``learning`` due date might take into
-account a student's cohort, individual due date extensions, accessibility
-allowances, and any number of other things. Both domains may call it ``due``,
+A subject should always mean the same thing within a subdomain, but can mean
+different things across subdomains. For instance, what the LMS (``learning``
+subdomain) calls a ``course`` might map to what the ``catalog`` subdomain would
+call a ``course_run``. We should try to be consistent where possible, but each
+subdomain ultimately gets to decide what its terms mean, and we should be
+careful when translating a concept from one subdomain to another. For instance,
+the ``content_authoring`` and ``learning`` subdomains might both have a concept
+of a "due date" for an assignment. But while the ``content_authoring`` due date
+is determined only by the content author, the ``learning`` due date might take
+into account a student's cohort, individual due date extensions, accessibility
+allowances, and any number of other things. Both subdomains may call it ``due``,
 but the due date information from ``content_authoring`` is just an input to the
 more complex due date information in ``learning``.
 
@@ -341,9 +341,9 @@ sure about what you're doing.
 Events are Created by the Owning Subdomain
 ------------------------------------------
 
-Teams at edX are broadly aligned to domains and roughly mapped to services.
-Services should not emit events for other domains. For instance, the ecommerce
-service is its own subdomain and should not be emitting ``catalog`` or
+Teams at edX are broadly aligned to subdomains and roughly mapped to services.
+Services should not emit events for other subdomains. For instance, the
+ecommerce service is its own subdomain and should not be emitting ``catalog`` or
 ``learning`` events. It is sometimes the case that a subdomain encompasses
 multiple services (e.g. Studio and Blockstore both operate on the
 ``content_authoring`` subdomain).
@@ -359,9 +359,9 @@ emits an event describing when a course starts (e.g.
 the LMS to send potentially conflicting information using that same event type.
 
 Two services may have similar sounding events. The course-discovery service
-(``catalog`` domain) might emit a ``org.openedx.catalog.course.created.v1``
+(``catalog`` subdomain) might emit a ``org.openedx.catalog.course.created.v1``
 event when a catalog entry for a course is created, while Studio
-(``content_authoring`` domain) might emit a
+(``content_authoring`` subdomain) might emit a
 ``org.openedx.content_authoring.course.created.v1`` event when course content is
 first authored there. These are similar, related events, but they are not the
 same event type.

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -306,9 +306,11 @@ Example: ``v1``
 
 The last portion is the major version of the message, starting with ``v1``. All
 messages will have a major and minor version, with the minor version encoded in
-the ``data`` attribute (todo: link to where we discuss that). New fields may be
-added to a message without incrementing the major version, but all additions
-*must* be backwards compatible.
+the ``minorversion`` attribute. New fields may be added to a message without
+incrementing the major version, but all additions *must* be backwards
+compatible. If you increment this to make a backwards-incompatible change, you
+will be expected to have a transition period where you are emitting the previous
+major version event as well as the new one.
 
 
 `time <https://github.com/cloudevents/spec/blob/master/spec.md#time>`_
@@ -326,7 +328,6 @@ actions. Do call ``datetime.now()`` if the event happens and has no
 corresponding database changes. If you are sending out multiple event messages
 describing the same occurance (e.g. a version 1 and version 2 of an event), they
 should have the *exact* same timestamp.
-
 
 
 Message Content Data Guidelines

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -117,8 +117,8 @@ example:
 .. code-block:: javascript
 
   {
-    "id": "83f8287e-56c2-11ea-a800-f2189839bdb6",
-    "source": "course-discovery???"
+    "id": "b3b3981e-7544-11ea-b663-acde48001122",
+    "source": "???"
     "specversion": "1.0",
     "time": "2020-02-23T09:00:00Z",
     "type": "org.openedx.catalog.v1.course.created"

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -28,8 +28,9 @@ OEP-41: Asynchronous Server Event Messaging
    * - References
      - ?
 
+--------
 Abstract
-========
+--------
 
 This OEP describes the conventions Open edX should use for asynchronous event
 messaging across services. These events would be emitted when a service has
@@ -43,24 +44,27 @@ This OEP does not cover:
   services. Events in this document are the services broadcasting, "Here is what
   I just did!" to interested parties, not "Please do this thing for me!"
 * Real-time streaming of student learning events to external platforms, as
-  detailed in `OEP-26: Real-time Events`_, though it is possible that the
-  implementation of OEP-26 might build on the infrastructure outlined in this
-  document.
+  detailed in `OEP-26 <oep-0026-realtime-events>`_, though it is possible that
+  the implementation of OEP-26 might build on the infrastructure outlined in
+  this document.
 * Browser level notifications and event streaming along the lines of
   Server-Sent-Events, GraphQL subscriptions, or frameworks built on top of
   WebSocket. The interactions here are strictly server to server interactions
-  between services serving the same site.
+  between services serving the same site. Again, it is entirely possible that
+  an implementation of browser level notifications would be built on top of the
+  infrastructure outlined here.
 
+
+----------
 Motivation
-==========
+----------
 
 Open edX has multiple services that need to copy data or take specific actions
 when certain events occur in other services. For example:
 
 * The start date of a course exists in both the Catalog domain represented by
   the course-discovery service, as well as in the LMS, where its value is used
-  to help determine whether an enrolled student will have access to the
-  content.
+  to help determine whether an enrolled student will have access to the content.
 * Other services often have a user table, with data replicated from the LMS
   (the place where users register today).
 * Publishing a new version of course content in Studio triggers a variety of
@@ -90,13 +94,14 @@ even more chaotic place where each pairing of services uses different
 conventions for this kind of communication.
 
 
+-------------
 Specification
-=============
+-------------
 
 Message Format
-~~~~~~~~~~~~~~
+==============
 
-The message format will use `CloudEvents 1.0
+The message format will use the `CloudEvents 1.0
 <https://github.com/cloudevents/spec/blob/master/spec.md>`_ specification, with
 additional usage conventions that all Open edX services should adhere to.
 CloudEvents was developed by the Cloud Native Computing Foundation, with
@@ -104,55 +109,166 @@ participation from major companies like Google, Microsoft, IBM, Red Hat, Oracle,
 and Huawei. While the finalized 1.0 spec is only months old and the Python
 tooling is primitive (advertised to break at any time), CloudEvents is also a
 pretty minimal message envelope spec, with the basic required fields being
-things that we'd have anyway.
+things that we'd want to have anyway.
 
-Event messages will be JSON documents < 64K. An example with comments:
+Event messages will be UTF-8 encoded JSON documents of 64 KB or less. An
+example:
 
 .. code-block:: javascript
 
   {
-    // Message ID. CloudEvents requires this to be a string that is unique for
-    // any given source. We can just use a UUID1 here, as it's simple to
-    // generate and there are no requirements around randomness.
     "id": "83f8287e-56c2-11ea-a800-f2189839bdb6",
-
-    // This should be the originating service, or some combination of
-    "source": "course-discovery/"
-
-    // Mandatory, and refers to the version of CloudEvents.
+    "source": "course-discovery???"
     "specversion": "1.0",
-
-    // CloudEvents only requires that this be a string describing the type of
-    // event, but recommends that it be prefixed with a reverse-DNS name for
-    // namespacing purposes. In this example, "org.openedx" is the generic
-    // prefix that would be used for all Open edX installs. The next component
-    // is the Domain, in this case "catalog". The next component is the version,
-    // (see versioning), followed by a noun + verb convention. Note that the
-    // nouns and verbs don't have to map directly onto CRUD operations. Also,
-    // verbs should be past-tense, for consistency with most of the tracking log
-    // events we currently emit.
-    //
-    // The standard ones will be: created/updated/deleted
-    "type": "org.openedx.catalog.v1.course.created"
-
-    // Time the message is created, in UTC using RFC3339. This should be
-    // separate from any "updated_at" sort of timestamp for a record update
-    // event, as the message may be generated long after the update actually
-    // happens.
     "time": "2020-02-23T09:00:00Z",
-
-    // TODO: source, dataschema, datacontenttype???
-
-    // This is domain-specific. We should have only the vaguest guidelines here,
-    // like to prefer underscored names to camelCase.
+    "type": "org.openedx.catalog.v1.course.created"
     "data": {
-
+        // message specific payload here
     }
   }
 
-Message Content Data Guidelines
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fields
+======
 
+All top level field names are specified by the CloudEvents spec, but most fields
+defined by that standard have some leeway in how they're used for any given
+system. Each field below has a link to CloudEvents requirements, as well as a
+description of the conventions Open edX will use for that field. All Open edX
+events should have all of the fields specified below (even if some are
+considered optional in the CloudEvents spec).
+
+`id <https://github.com/cloudevents/spec/blob/master/spec.md#id>`_
+------------------------------------------------------------------
+
+Example: ``"b3b3981e-7544-11ea-b663-acde48001122"``
+
+Message ID. CloudEvents requires this to be a string that is unique for any
+given source. We will use a UUID1 here, since it is easy to generate without
+worrying about collisions, and it offers slightly more useful introspection
+(timestamp and machine) than a random UUID4. The UUID will be encoded as a
+string using Python's default behavior: lowercase and and dash-separated.
+
+`source <https://github.com/cloudevents/spec/blob/master/spec.md#source-1>`_
+-----------------------------------------------------------------------------
+
+Example:
+
+If it is being hosted under a different domain, is the source expected to be
+different?
+
+
+`specversion <https://github.com/cloudevents/spec/blob/master/spec.md#specversion>`_
+------------------------------------------------------------------------------------
+
+Always: ``"1.0"``
+
+Mandatory field that refers to the version of CloudEvents. We have to use "1.0"
+to be spec-compliant.
+
+`type <https://github.com/cloudevents/spec/blob/master/spec.md#type>`_
+----------------------------------------------------------------------
+
+Example: ``"org.openedx.catalog.course.created.v1"``
+
+This is the name of our event. CloudEvents only requires that this be a string
+describing the type of event, but recommends that it be prefixed with a
+reverse-DNS name for namespacing purposes. We will use a period-separated
+hierarchical name comprising with the format ``{Reverse DNS}-{Architecture
+Domain}-{Subject}-{Action}-{Major Version}``.
+
+
+Reverse DNS
+~~~~~~~~~~~
+
+Example: ``org.openedx``
+
+In this example, ``org.openedx`` is the generic prefix that would be used for
+all Open edX installs. Events that are strictly edX-specific, like those that
+might interact with internal IT or finance reporting systems, should use
+``org.edx`` as the prefix instead. If in doubt, default to ``org.openedx``.
+
+Domain (from Domain Driven Design)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Example: ``catalog``
+
+The next part of the ``type`` hierarchy is the Domain. Examples of this are:
+
+* catalog
+* content_authoring
+* credentials
+* learning
+
+It is the expectation that there are relatively few domains, and that they will
+roughly match deployed services. Domain names should be lower cased and use
+underscores if they are more than one word.
+
+Subject
+~~~~~~~
+
+Example: ``course``
+
+The name of an entity that the event applies to. Examples might be ``course``,
+``student``, ``enrollment``, ``order``, etc. Subjects may be namespaced, so
+``special_exam.proctored.allowance`` could be a subject. A subject should always
+mean the same thing within a Domain, but can mean different things across
+domains. For instance, what the LMS (``learning`` domain) calls a ``course``
+maps to what the ``catalog`` domain would call a ``course_run``. We should try
+to be consistent where possible, but each domain ultimately gets to decide what
+its terms means, and we should be careful when mapping a concept in one domain
+to concepts in another domain.
+
+Action
+~~~~~~
+
+Example: ``created``
+
+This is the action that occurred for the event. Some of most common ones will be
+``created``, ``updated``, and ``deleted``, but many applications will want more
+specific actions like ``declined``, ``started``, ``verified``, etc. Actions
+should be past tense, to better align with our existing conventions around
+Django signals and learning analytics events (we're not completely consistent,
+but we tend towards past tense).
+
+Major Version
+~~~~~~~~~~~~~
+
+Example: ``v1``
+
+The last portion is the major version of the message, starting with ``v1``. All
+messages will have a major and minor version, with the minor version encoded in
+the ``data`` attribute (todo: link to where we discuss that). New fields may be
+added to a message without incrementing the major version, but all additions
+*must* be backwards compatible. (Todo: link to more info on backwards
+compatibility.)
+
+`datacontenttype <https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype>`_
+--------------------------------------------------------------------------------------------
+
+Example: ``"application/json"``
+
+`RFC 2046 <https://tools.ietf.org/html/rfc2046>`_ string value describing the
+format of ``data`` attribute. It should be ``application/json`` the vast
+majority of the time, but some events might have ``text/xml``.
+
+
+`time <https://github.com/cloudevents/spec/blob/master/spec.md#time>`_
+----------------------------------------------------------------------
+
+Timestamp that the event occurred, in UTC using `RFC 3339
+<https://tools.ietf.org/html/rfc3339>`_. If this event was sent because we
+created a new row in the database, we should pull this ``time`` directly from
+the ``created_at`` field in that model so that the output matches exactly. Do
+*not* call ``datetime.now()`` in these situations because we will get times
+that are just a few milliseconds offset from the database record of these
+actions. Do call ``datetime.now()`` if the event happens and has no
+corresponding database changes. If you are sending out multiple event messages
+describing the same occurance (e.g. a version 1 and version 2 of an event), they
+should have the *exact* same timestamp.
+
+
+Message Content Data Guidelines
+===============================
 
 Avoid Callbacks
 ---------------
@@ -181,14 +297,14 @@ this scenario, doubling the consumers that my service has now also doubles the
 load that my service is placing on the REST endpoint serving this user
 information. Is that safe? Who knows?
 
-One thing to consider is that whether we can emit multiple events that better
-target specific consumer use cases. Let's take the "course_published" event as
-an example. Some listeners only care about schedule changes, because they have
-to account for when a course starts and ends. Search indexing really only wants
-to know the exact bit of content that was modified so that it can update that
-text. There is no rule that says a single user action has to translate into a
-single event. Be mindful of what your consumers actually care about and the
-broad use cases you're trying to serve.
+One thing to consider is whether we can emit multiple events that better target
+specific consumer use cases. Let's take the "course_published" event as an
+example. Some listeners only care about schedule changes, because they have to
+account for when a course starts and ends. Search indexing really only wants to
+know the exact bit of content that was modified so that it can update that text.
+There is no rule that says a single user action has to translate into a single
+event. Be mindful of what your consumers actually care about and the broad use
+cases you're trying to serve.
 
 If a callback is still necessary, try to make sure that it points to an
 especially robust and performant endpoint. For instance, an event that is fired
@@ -198,12 +314,24 @@ read long after they're generated, and any presigned S3 URLs you generate might
 be expired by the time a consumer gets them.
 
 
+Scratch Notes
+=============
 
+(Just jotting down ideas here:)
 
+Ordering considerations? Race conditions?
 
+Getting a catalog snapshot of all events major + minor version at any given time
+(like for a named release)
 
+Testing strategies to improve backwards compatibility.
 
+Library/code POC?
 
+exchange mapping
+
+Granularity of events (e.g. not just a course published, but what changed, use
+cases, schedule data, etc.)
 
 1. Self-contained, without history
 2. PII
@@ -214,49 +342,39 @@ be expired by the time a consumer gets them.
    that might have to read can actually do so without race).
 
 Transport Layer
-~~~~~~~~~~~~~~~
 
 Kombu, Redis as default.
 
 Versioning
-~~~~~~~~~~~
+
+Major/minor versioning.
+Envelope in data attribute, including minor version info.
 
 Testing and Ensuring Compatibility
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Bootstrapping
-~~~~~~~~~~~~~
 
 Documentation
-~~~~~~~~~~~~~
 
 (AsyncAPI)
 
 
-
-
-
+Top level concerns:
 
 Rationale
-=========
-
 
 
 Backward Compatibility
-======================
 
 
 
 Reference Implementation
-========================
 
 
 
 Rejected Alternatives
-=====================
 
 
 
 Change History
-==============
 

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -121,7 +121,7 @@ example:
     "source": "???"
     "specversion": "1.0",
     "time": "2020-02-23T09:00:00Z",
-    "type": "org.openedx.catalog.v1.course.created"
+    "type": "org.openedx.catalog.course.created.v1"
     "data": {
         // message specific payload here
     }

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -54,7 +54,7 @@ This OEP does not cover:
 Motivation
 ==========
 
-Open edX has multiple services that need to copy data or take certain actions
+Open edX has multiple services that need to copy data or take specific actions
 when certain events occur in other services. For example:
 
 * The start date of a course exists in both the Catalog domain represented by
@@ -70,39 +70,41 @@ when certain events occur in other services. For example:
 * Grading events in the LMS may trigger certificate generation if the user has
   exceeded the required threshold.
 
-The number of services is steadily growing, and the ad hoc synchronization and
-communication methods we've implemented over the years have caused us a great
-deal of operational pain, particularly around course discovery. At the same
-time, recent discussions around Domain Driven Design and data replication have
-given us a better framing for the kind of relationship we want to have between
-various services. There has also been a strong desire for a properly documented
-set of integration APIs that would allow Open edX to better interoperate with
-other applications in the ecosystem.
+Open edX services already use `Django signals
+<https://docs.djangoproject.com/en/1.11/topics/signals/>`_ for subscribing to
+events within the same service, but we have no accepted recommendation for how
+to do something similar across service boundaries. As the number of services in
+Open edX has grown, the various ad hoc synchronization and communication methods
+we've implemented over the years have caused numerous operational and
+performance problems (particularly around catalog data). At the same time,
+recent discussions around Domain Driven Design and data replication have given
+us a better framing for the kind of relationship we want to have between various
+services. There has also been a strong desire for a properly documented set of
+integration APIs that would allow Open edX to better interoperate with other
+applications in the ecosystem.
 
-There is an opportunity to bring this all these elements together and create a
-solid foundation for simple, reliable, and near real-time inter-service
-communication. But without some planning and design work, we may end up in an
+There is an opportunity to bring all these elements together and create a solid
+foundation for simple, reliable, well documented, near real-time cross-service
+message passing. But without some planning and design work, we may end up in an
 even more chaotic place where each pairing of services uses different
-conventions for messaging each other.
+conventions for this kind of communication.
 
 
 Specification
 =============
 
-
-
 Message Format
 ~~~~~~~~~~~~~~
 
-The message format will use
-`CloudEvents 1.0 <https://github.com/cloudevents/spec/blob/master/spec.md>`_
-specification, with additional usage conventions that all Open edX services
-should adhere to. CloudEvents was developed by the Cloud Native Computing
-Foundation, with participation from major companies like Google, Microsoft, IBM,
-Red Hat, Oracle, and Huawei. While the finalized spec is only months old and the
-Python tooling is primitive (advertised to break at any time), CloudEvents is
-also a pretty minimal message envelope spec, with the basic required fields
-being things that we'd have anyway.
+The message format will use `CloudEvents 1.0
+<https://github.com/cloudevents/spec/blob/master/spec.md>`_ specification, with
+additional usage conventions that all Open edX services should adhere to.
+CloudEvents was developed by the Cloud Native Computing Foundation, with
+participation from major companies like Google, Microsoft, IBM, Red Hat, Oracle,
+and Huawei. While the finalized 1.0 spec is only months old and the Python
+tooling is primitive (advertised to break at any time), CloudEvents is also a
+pretty minimal message envelope spec, with the basic required fields being
+things that we'd have anyway.
 
 Event messages will be JSON documents < 64K. An example with comments:
 
@@ -113,6 +115,9 @@ Event messages will be JSON documents < 64K. An example with comments:
     // any given source. We can just use a UUID1 here, as it's simple to
     // generate and there are no requirements around randomness.
     "id": "83f8287e-56c2-11ea-a800-f2189839bdb6",
+
+    // This should be the originating service, or some combination of
+    "source": "course-discovery/"
 
     // Mandatory, and refers to the version of CloudEvents.
     "specversion": "1.0",
@@ -145,14 +150,68 @@ Event messages will be JSON documents < 64K. An example with comments:
     }
   }
 
-Message Content Guidelines
+Message Content Data Guidelines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Avoid callbacks.
-2. Self-contained if at all possible.
-3. Can have pointers to large static resources if necessary?
+
+Avoid Callbacks
+---------------
+
+A callback is when you create a message with an ID or URL that you expect the
+consumer to make a synchronous call to when it receives the message. This is
+commonly used when an event represents some change that is too large to
+practically fit into the 64K message. For instance, we currently emit a generic
+"course_published" Django signal whenever data is published in Studio, leading
+to a cascade of calls from various apps to the ModuleStore in order to extract
+the content data that they need.
+
+Callbacks threaten performance and stability because they reduce a service's
+ability to control its own load. For instance, a sudden increase in Courseware
+traffic might generate a burst of student analytics events. If this stream of
+events overwhelms my service's ability to consume them, the queue may start to
+back up with unread events. Yet this shouldn't cause my service to fail, since
+it still gets to control how quicky it consumes events off of that queue. It has
+the freedom to either slowly catch up (if the burst was a momentary spike), or
+to scale up additional workers to handle the higher throughput. My service's
+decision to scale up or down does not directly impact other services.
+
+Things change when we introduce a callback to this same scenario. Say the
+analytics events now include a callback URL to get basic user information. In
+this scenario, doubling the consumers that my service has now also doubles the
+load that my service is placing on the REST endpoint serving this user
+information. Is that safe? Who knows?
+
+One thing to consider is that whether we can emit multiple events that better
+target specific consumer use cases. Let's take the "course_published" event as
+an example. Some listeners only care about schedule changes, because they have
+to account for when a course starts and ends. Search indexing really only wants
+to know the exact bit of content that was modified so that it can update that
+text. There is no rule that says a single user action has to translate into a
+single event. Be mindful of what your consumers actually care about and the
+broad use cases you're trying to serve.
+
+If a callback is still necessary, try to make sure that it points to an
+especially robust and performant endpoint. For instance, an event that is fired
+when a user changes their profile information might include a URL to the S3
+location of their new profile picture. Just keep in mind that messages may be
+read long after they're generated, and any presigned S3 URLs you generate might
+be expired by the time a consumer gets them.
+
+
+
+
+
+
+
+
+
+1. Self-contained, without history
+2. PII
 4. No RPC
 5. Exchange = Domain, routing key = event type. Namespacing excessive?
+6. Shouldn't emit before data is committed to the database. on_commit practice?
+   (both to prevent mismatch on error as well as to make sure something else
+   that might have to read can actually do so without race).
 
 Transport Layer
 ~~~~~~~~~~~~~~~

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -1,0 +1,203 @@
+=============================================
+OEP-41: Asynchronous Server Event Messaging
+=============================================
+
+.. list-table::
+   :widths: 25 75
+
+   * - OEP
+     - :doc:`OEP-41 </oeps/oep-0041-arch-async-server-event-messaging.rst>`
+   * - Title
+     - Asynchronous Server Messaging
+   * - Last Modified
+     - 2020-02-23
+   * - Authors
+     - David Ormsbee <dave@edx.org>
+   * - Arbiter
+     - ?
+   * - Status
+     - Draft
+   * - Type
+     - Architecture (? Best Practice?)
+   * - Created
+     - 2020-02-23
+   * - Review Period
+     - ?
+   * - Resolution
+     - ?
+   * - References
+     - ?
+
+Abstract
+========
+
+This OEP describes the conventions Open edX should use for asynchronous event
+messaging across services. These events would be emitted when a service has
+taken some action to data that it owns, and that other services would be
+interested in. This could be a course publish, a user enrollment, updates to
+catalog metadata, etc.
+
+This OEP does not cover:
+
+* Remote Prodecure Calls, i.e. using messaging to send commands to other
+  services. Events in this document are the services broadcasting, "Here is what
+  I just did!" to interested parties, not "Please do this thing for me!"
+* Real-time streaming of student learning events to external platforms, as
+  detailed in `OEP-26: Real-time Events`_, though it is possible that the
+  implementation of OEP-26 might build on the infrastructure outlined in this
+  document.
+* Browser level notifications and event streaming along the lines of
+  Server-Sent-Events, GraphQL subscriptions, or frameworks built on top of
+  WebSocket. The interactions here are strictly server to server interactions
+  between services serving the same site.
+
+Motivation
+==========
+
+Open edX has multiple services that need to copy data or take certain actions
+when certain events occur in other services. For example:
+
+* The start date of a course exists in both the Catalog domain represented by
+  the course-discovery service, as well as in the LMS, where its value is used
+  to help determine whether an enrolled student will have access to the
+  content.
+* Other services often have a user table, with data replicated from the LMS
+  (the place where users register today).
+* Publishing a new version of course content in Studio triggers a variety of
+  LMS tasks to query and re-build optimized versions of course data for various
+  systems like the Block Transformers that power the mobile application and
+  course outline.
+* Grading events in the LMS may trigger certificate generation if the user has
+  exceeded the required threshold.
+
+The number of services is steadily growing, and the ad hoc synchronization and
+communication methods we've implemented over the years have caused us a great
+deal of operational pain, particularly around course discovery. At the same
+time, recent discussions around Domain Driven Design and data replication have
+given us a better framing for the kind of relationship we want to have between
+various services. There has also been a strong desire for a properly documented
+set of integration APIs that would allow Open edX to better interoperate with
+other applications in the ecosystem.
+
+There is an opportunity to bring this all these elements together and create a
+solid foundation for simple, reliable, and near real-time inter-service
+communication. But without some planning and design work, we may end up in an
+even more chaotic place where each pairing of services uses different
+conventions for messaging each other.
+
+
+Specification
+=============
+
+
+
+Message Format
+~~~~~~~~~~~~~~
+
+The message format will use
+`CloudEvents 1.0 <https://github.com/cloudevents/spec/blob/master/spec.md>`_
+specification, with additional usage conventions that all Open edX services
+should adhere to. CloudEvents was developed by the Cloud Native Computing
+Foundation, with participation from major companies like Google, Microsoft, IBM,
+Red Hat, Oracle, and Huawei. While the finalized spec is only months old and the
+Python tooling is primitive (advertised to break at any time), CloudEvents is
+also a pretty minimal message envelope spec, with the basic required fields
+being things that we'd have anyway.
+
+Event messages will be JSON documents < 64K. An example with comments:
+
+.. code-block:: javascript
+
+  {
+    // Message ID. CloudEvents requires this to be a string that is unique for
+    // any given source. We can just use a UUID1 here, as it's simple to
+    // generate and there are no requirements around randomness.
+    "id": "83f8287e-56c2-11ea-a800-f2189839bdb6",
+
+    // Mandatory, and refers to the version of CloudEvents.
+    "specversion": "1.0",
+
+    // CloudEvents only requires that this be a string describing the type of
+    // event, but recommends that it be prefixed with a reverse-DNS name for
+    // namespacing purposes. In this example, "org.openedx" is the generic
+    // prefix that would be used for all Open edX installs. The next component
+    // is the Domain, in this case "catalog". The next component is the version,
+    // (see versioning), followed by a noun + verb convention. Note that the
+    // nouns and verbs don't have to map directly onto CRUD operations. Also,
+    // verbs should be past-tense, for consistency with most of the tracking log
+    // events we currently emit.
+    //
+    // The standard ones will be: created/updated/deleted
+    "type": "org.openedx.catalog.v1.course.created"
+
+    // Time the message is created, in UTC using RFC3339. This should be
+    // separate from any "updated_at" sort of timestamp for a record update
+    // event, as the message may be generated long after the update actually
+    // happens.
+    "time": "2020-02-23T09:00:00Z",
+
+    // TODO: source, dataschema, datacontenttype???
+
+    // This is domain-specific. We should have only the vaguest guidelines here,
+    // like to prefer underscored names to camelCase.
+    "data": {
+
+    }
+  }
+
+Message Content Guidelines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Avoid callbacks.
+2. Self-contained if at all possible.
+3. Can have pointers to large static resources if necessary?
+4. No RPC
+5. Exchange = Domain, routing key = event type. Namespacing excessive?
+
+Transport Layer
+~~~~~~~~~~~~~~~
+
+Kombu, Redis as default.
+
+Versioning
+~~~~~~~~~~~
+
+Testing and Ensuring Compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bootstrapping
+~~~~~~~~~~~~~
+
+Documentation
+~~~~~~~~~~~~~
+
+(AsyncAPI)
+
+
+
+
+
+
+Rationale
+=========
+
+
+
+Backward Compatibility
+======================
+
+
+
+Reference Implementation
+========================
+
+
+
+Rejected Alternatives
+=====================
+
+
+
+Change History
+==============
+

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -1,6 +1,6 @@
-=============================================
-OEP-41: Asynchronous Server Event Messaging
-=============================================
+================================================
+OEP-41: Asynchronous Server Event Message Format
+================================================
 
 .. list-table::
    :widths: 25 75
@@ -8,7 +8,7 @@ OEP-41: Asynchronous Server Event Messaging
    * - OEP
      - :doc:`OEP-41 </oeps/oep-0041-arch-async-server-event-messaging.rst>`
    * - Title
-     - Asynchronous Server Messaging
+     - Asynchronous Server Event Message Format
    * - Last Modified
      - 2020-02-23
    * - Authors

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -31,7 +31,7 @@ Abstract
 --------
 
 This OEP describes the general format and conventions Open edX should use in
-asynchornous event messaging across services. These events would be emitted when
+asynchronous event messaging across services. These events would be emitted when
 a service has taken some action to data that it owns, and that other services
 would be interested in. This could be a course publish, a user enrollment,
 updates to catalog metadata, etc.

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -140,15 +140,6 @@ events should have all of the fields specified below (even if some are
 considered optional in the CloudEvents spec).
 
 
-`dataschema <https://github.com/cloudevents/spec/blob/master/spec.md#dataschema>`_
-----------------------------------------------------------------------------------
-
-Example: ???
-
-WIP: This would link to documentation? Fill this out after we flesh out that
-portion of this OEP.
-
-
 `datacontenttype <https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype>`_
 --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This OEP describes the general format and conventions Open edX should use in asynchornous event messaging across services. These events would be emitted when a service has taken some action to data that it owns, and that other services would be interested in. This could be a course publish, a user enrollment, updates to catalog metadata, etc.

This OEP does not cover:

* Remote Prodecure Calls, i.e. using messaging to send commands to other services. Events in this document are the services broadcasting, "Here is what I just did!" to interested parties, not "Please do this thing for me!"
* Real-time streaming of student learning events to external platforms, as detailed in [OEP-26](https://open-edx-proposals.readthedocs.io/en/latest/oep-0026-arch-realtime-events.html), though it is possible that the implementation of OEP-26 might build on the infrastructure outlined in this document.
* Browser level notifications and event streaming along the lines of Server-Sent-Events, GraphQL subscriptions, or frameworks built on top of WebSocket. The interactions here are strictly server to server interactions between services serving the same site. Again, it is entirely possible that an implementation of browser level notifications would be built on top of the infrastructure outlined here.
* The specific transport and libraries used for this messaging. That will be specified in a follow-on OEP.