### PR TITLE
[ARCHBOM-1206] Modifying OEP2: Make owner key optional

### DIFF
--- a/oeps/oep-0002-bp-repo-metadata.rst
+++ b/oeps/oep-0002-bp-repo-metadata.rst
@@ -44,7 +44,7 @@ Each repo will include a file ``openedx.yaml``, with the following keys:
 
 ``owner``: dictionary (optional)
     This key contains information about the assigned owner of this repository.
-    **Note:** Initially, the key was intended as info about ownership and about who to contact for repo related issues. Ownership info has now been moved to an edx internal location and we plan on adding contact point info to repos at some point in the future. The exact location still to be determined, possible in openedx.yaml or CODEOWNERS file.
+    **Note:** Initially, the key served two purposes: assigning ownership of the repository and as a who to contact for repo related issues. Ownership info has now been moved to an edx internal location. As for contact info, this is still WIP. We plan on adding contact point info to repos at some point in the future. The exact location is still to be determined, possible in openedx.yaml or CODEOWNERS file.
 
     ``type``: string (optional)
         The value of this key must be either ``team`` or ``repo``. It indicates which ownership model applies to this repository, and therefore which of these two keys should exist with a non-empty value.

--- a/oeps/oep-0002-bp-repo-metadata.rst
+++ b/oeps/oep-0002-bp-repo-metadata.rst
@@ -44,7 +44,7 @@ Each repo will include a file ``openedx.yaml``, with the following keys:
 
 ``owner``: dictionary (optional)
     This key contains information about the assigned owner of this repository.
-    **Note:** Initially, the key served two purposes: assigning ownership of the repository and as a who to contact for repo related issues. Ownership info has now been moved to an edx internal location. As for contact info, this is still WIP. We plan on adding contact point info to repos at some point in the future. The exact location is still to be determined, possible in openedx.yaml or CODEOWNERS file.
+    **Note:** Initially, the key served two purposes: assigning ownership of the repository and as a "who to contact" for repo related issues. Ownership info has now been moved to an edx internal location. As for contact info, this is still WIP. We plan on adding contact point to repos at some point in the future. The exact location is still to be determined, possible in openedx.yaml or CODEOWNERS file.
 
     ``type``: string (optional)
         The value of this key must be either ``team`` or ``repo``. It indicates which ownership model applies to this repository, and therefore which of these two keys should exist with a non-empty value.

--- a/oeps/oep-0002-bp-repo-metadata.rst
+++ b/oeps/oep-0002-bp-repo-metadata.rst
@@ -42,10 +42,10 @@ Keys
 
 Each repo will include a file ``openedx.yaml``, with the following keys:
 
-``owner``: dictionary (required)
+``owner``: dictionary (optional)
     This key contains information about the assigned owner of this repository.
 
-    ``type``: string (required)
+    ``type``: string (optional)
         The value of this key must be either ``team`` or ``repo``. It indicates which ownership model applies to this repository, and therefore which of these two keys should exist with a non-empty value.
 
         **Note:** As much as possible, repos should be owned by higher-level repos, with only the highest-level repos owned by teams.

--- a/oeps/oep-0002-bp-repo-metadata.rst
+++ b/oeps/oep-0002-bp-repo-metadata.rst
@@ -44,6 +44,7 @@ Each repo will include a file ``openedx.yaml``, with the following keys:
 
 ``owner``: dictionary (optional)
     This key contains information about the assigned owner of this repository.
+    **Note:** Initially, the key was intended as info about ownership and about who to contact for repo related issues. Ownership info has now been moved to an edx internal location and we plan on adding contact point info to repos at some point in the future. The exact location still to be determined, possible in openedx.yaml or CODEOWNERS file.
 
     ``type``: string (optional)
         The value of this key must be either ``team`` or ``repo``. It indicates which ownership model applies to this repository, and therefore which of these two keys should exist with a non-empty value.

--- a/oeps/oep-0002-bp-repo-metadata.rst
+++ b/oeps/oep-0002-bp-repo-metadata.rst
@@ -44,7 +44,6 @@ Each repo will include a file ``openedx.yaml``, with the following keys:
 
 ``owner``: dictionary (optional)
     This key contains information about the assigned owner of this repository.
-    **Note:** Initially, the key served two purposes: assigning ownership of the repository and as a "who to contact" for repo related issues. Ownership info has now been moved to an edx internal location. As for contact info, this is still WIP. We plan on adding contact point to repos at some point in the future. The exact location is still to be determined, possible in openedx.yaml or CODEOWNERS file.
 
     ``type``: string (optional)
         The value of this key must be either ``team`` or ``repo``. It indicates which ownership model applies to this repository, and therefore which of these two keys should exist with a non-empty value.
@@ -220,6 +219,12 @@ Keeping the granularity of **human owners to individual teams** affords us:
 
 Change History
 ==============
+
+2020-06-08
+----------
+
+* Made Owner key optional
+  * Initially, the key served two purposes: assigning ownership of the repository and as a "who to contact" for repo related issues. Ownership info has now been moved to an edx internal location. As for contact info, this is still WIP. We plan on adding contact point to repos at some point in the future. The exact location is still to be determined, possible in openedx.yaml or CODEOWNERS file.
 
 2019-12-11
 ----------


### PR DESCRIPTION
See for more details: https://openedx.atlassian.net/browse/ARCHBOM-1206

Originally, the intention was to openedx.yaml as the source of truth for ownership info. However, as the ownership initiative has progressed, the [ownership google sheet](https://docs.google.com/spreadsheets/d/1qpWfbPYLSaE_deaumWSEZfz91CshWd3v3B7xhOk5M4U/edit#gid=840878297) has become the source. It was decided asking everyone to switch to openedx.yaml as source of truth is not necessary in the short term and would distract from other things that need to be done for the ownership effort. 

The change in this PR is meant to align OEP-2 with current plans for ownership.

