### PR TITLE
Update edx-sphinx-theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-edx-sphinx-theme==1.0.1
+edx-sphinx-theme==1.5.0
 sphinx==1.4.8


### PR DESCRIPTION
Updating edx-sphinx-theme in order to get dynamic copyright at bottom of page and associated updates/security fixes.

Right now copyright at bottom of page says 2016; https://github.com/edx/edx-sphinx-theme/pull/12 made this dynamic