### PR TITLE
fix: Use copy of spreadsheet owned by edX Google account

### DIFF
--- a/oeps/oep-0026/caliper-realtime-events.rst
+++ b/oeps/oep-0026/caliper-realtime-events.rst
@@ -209,7 +209,7 @@ Event Field Mapping
 Please see the `Open edX Caliper Events`_ document for a detailed view of the mapping between the above Open edX events and their equivalent Open edX Caliper formats.
 
 
-.. _Open edX Caliper Events: https://docs.google.com/spreadsheets/d/1z_1IGFVDF-wZToKS2EGXFR3s0NXoh6tTKhEtDkevFEM/edit?usp=sharing
+.. _Open edX Caliper Events: https://docs.google.com/spreadsheets/d/1MgHddOO6G33sSpknvYi-aXuLiBmuKTfHmESsXpIiuU8/view
 
 .. |ecosystem| image:: ./caliper_ecosystem.png
    :width: 6.5in

--- a/oeps/oep-0026/xapi-realtime-events.rst
+++ b/oeps/oep-0026/xapi-realtime-events.rst
@@ -234,7 +234,7 @@ Event Field Mapping
 
 Please see the `Open edx xAPI Events`_ document for a detailed view of the mapping between the above Open edX events and their equivalent Open edX xAPI formats.
 
-.. _Open edx xAPI Events: https://docs.google.com/spreadsheets/d/1Qx-1NkpCHXkWh8AagwHD5vzyBCdRXQVof10Ent_EDms/edit?usp=sharing
+.. _Open edx xAPI Events: https://docs.google.com/spreadsheets/d/1oTClCxuUj1vCzytbmjDaHWFmcI6JZDqqJtZmYVwnOTA/view
 
 Implementation Note
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Caliper spreadsheet had previously become inaccessible. This should reduce
the risk of that happening again.