### PR TITLE
fix: use correct rst table syntax and add toc

### DIFF
--- a/oeps/oep-0051-bp-conventional-commits.rst
+++ b/oeps/oep-0051-bp-conventional-commits.rst
@@ -26,9 +26,13 @@ OEP-0051: Conventional Commits
    * - Resolution
      - TK
    * - References
-     - `Conventional Commits`_
-     - `Change Transparency`_
+     -
+       - `Conventional Commits`_
+       - `Change Transparency`_
 
+.. contents::
+   :local:
+   :depth: 1
 
 Abstract
 ========


### PR DESCRIPTION
The table wasn't appearing because the last cell had three columns.  Use
the correct syntax to make the last cell have a bullet list in it.