### PR TITLE
BOM-2461: Add readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the oeps/ directory with Sphinx
+sphinx:
+   configuration: oeps/conf.py
+
+python:
+   version: 3.8
+   install:
+   - requirements: requirements/dev.txt


### PR DESCRIPTION
Adding configuration file for building documents by Read the Docs.
**For details**:
https://docs.readthedocs.io/en/stable/config-file/v2.html