### PR TITLE
docs: Adding Decisions section to OEP-005 + feat: Adding Edit on Github button

### DIFF
--- a/oeps/conf.py
+++ b/oeps/conf.py
@@ -56,6 +56,14 @@ project = u'Open edX Proposals'
 author = edx_theme.AUTHOR
 copyright = edx_theme.COPYRIGHT
 
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "edx", # Username
+    "github_repo": "open-edx-proposals", # Repo name
+    "github_version": "master", # Version
+    "conf_py_path": "/oeps/", # Path in the checkout to the docs root
+}
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/oeps/oep-0005-arch-containerize-devstack.rst
+++ b/oeps/oep-0005-arch-containerize-devstack.rst
@@ -232,6 +232,19 @@ environment, and was the prototype implementation of this OEP. However, it
 will need modification to fully meet the specifications of this OEP.
 
 
+Related Decisions
+=================
+
+The following related decisions modify or enhance this OEP, but have not yet been fully incorporated as updates to this OEP:
+
+.. toctree::
+   :caption: OEP-5 Decisions
+   :maxdepth: 1
+   :glob:
+
+   oep-0005/decisions/*
+
+
 Change History
 ==============
 


### PR DESCRIPTION
Adding "Edit on Github" button to make it easier to correct documentation
Adding decisions to OEP-0005 to increase visibility. This potentially creates an informal standard for how to add decisions to oeps.