### PR TITLE
chore: Change http URLs to https

### DIFF
--- a/oeps/oep-0001.rst
+++ b/oeps/oep-0001.rst
@@ -39,7 +39,7 @@ OEP-1: OEP Purpose and Guidelines
 .. _open-edx-proposals#85: https://github.com/edx/open-edx-proposals/pull/85
 .. _open-edx-proposals#1 resolution: https://github.com/edx/open-edx-proposals/pull/1#issuecomment-220419055
 .. _PEP: https://www.python.org/dev/peps/pep-0001/
-.. _Architecture Decision Records: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+.. _Architecture Decision Records: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
 
 .. contents::
   :local:
@@ -151,7 +151,7 @@ available number.
 The pull request title should be of the form "OEP-XXXX: <OEP title>", where
 *XXXX* is the OEP number claimed for the included proposal.
 
-.. _central OEP repository: http://github.com/edx/open-edx-proposals
+.. _central OEP repository: https://github.com/edx/open-edx-proposals
 
 Step 3. Review with Arbiter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oeps/oep-0003-arch-async-tasks.rst
+++ b/oeps/oep-0003-arch-async-tasks.rst
@@ -86,7 +86,7 @@ features:
 * When the task is complete, the task requester will be sent an email to that
   effect (including a link to the task status page).
 * The user will be able to cancel a task. Celery's
-  `revoke <http://docs.celeryproject.org/en/latest/userguide/workers.html#revoke-revoking-tasks>`_
+  `revoke <https://docs.celeryproject.org/en/latest/userguide/workers.html#revoke-revoking-tasks>`_
   command will be used to cancel a task which hasn't started execution yet,
   and the implementation of this OEP will include an API which tasks should
   use periodically to determine if execution should be aborted.

--- a/oeps/oep-0006-arch-context-xblock-fields.rst
+++ b/oeps/oep-0006-arch-context-xblock-fields.rst
@@ -50,7 +50,7 @@ with particular environment(s) and user(s). A field's ``Scope`` is generally a
 composite property, defined as the combination of a ``BlockScope``, a
 ``UserScope``, and a ``name``.
 
-.. _scopes: http://edx.readthedocs.io/projects/xblock/en/latest/fields.html
+.. _scopes: https://edx.readthedocs.io/projects/xblock/en/latest/fields.html
 
 For reference, the ``UserScope`` can have three values (no changes to these are
 being proposed):
@@ -192,7 +192,7 @@ that define the ``context_settings_view``. Clicking on the name of that XBlock
 would display the HTML fragment and allow the author to edit the context-scoped
 fields.
 
-.. _studio_view: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/edx_studio.html
+.. _studio_view: https://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/edx_studio.html
 
 Context-scoped fields in OLX (Provisional)
 ------------------------------------------
@@ -237,7 +237,7 @@ The reasoning behind the above provisional spec is as follows:
 * ``<xblock-settings>`` is suggested as a wrapper to keep these new XML nodes
   organized and indicate their purpose clearly.
 
-.. _(docs): http://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/directory-structure.html#top-level-directory
+.. _(docs): https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/directory-structure.html#top-level-directory
 
 Rationale
 =========

--- a/oeps/oep-0009-bp-permissions.rst
+++ b/oeps/oep-0009-bp-permissions.rst
@@ -189,8 +189,8 @@ permission to anonymous users and assumes that there are no ``view_*``
 permissions relevant to viewing or listing objects; those points can be
 changed if desired by creating a subclass, for example:
 
-.. _DjangoObjectPermissions: http://www.django-rest-framework.org/api-guide/permissions/#djangoobjectpermissions
-.. _set the permissions policy: http://www.django-rest-framework.org/api-guide/permissions/#setting-the-permission-policy
+.. _DjangoObjectPermissions: https://www.django-rest-framework.org/api-guide/permissions/#djangoobjectpermissions
+.. _set the permissions policy: https://www.django-rest-framework.org/api-guide/permissions/#setting-the-permission-policy
 
 .. code-block:: python
 
@@ -244,8 +244,8 @@ proposed above for mapping permissions to Q objects might look as follows:
 Such a class would be used in a view's `filter_backends`_ attribute or
 could be used by default for all view classes which don't override it.
 
-.. _BasePermission: http://www.django-rest-framework.org/api-guide/permissions/#custom-permissions
-.. _filter_backends: http://www.django-rest-framework.org/api-guide/filtering/#setting-filter-backends
+.. _BasePermission: https://www.django-rest-framework.org/api-guide/permissions/#custom-permissions
+.. _filter_backends: https://www.django-rest-framework.org/api-guide/filtering/#setting-filter-backends
 
 Rationale
 =========

--- a/oeps/oep-0012-arch-fragment-views.rst
+++ b/oeps/oep-0012-arch-fragment-views.rst
@@ -542,7 +542,7 @@ A list of dated sections that describes a brief summary of each revision of the 
 .. _How we switched our template rendering engine to React: https://engineering.pinterest.com/blog/how-we-switched-our-template-rendering-engine-react
 .. _Nunjucks Asynchronous Support: https://mozilla.github.io/nunjucks/api.html#asynchronous-support
 .. _jQuery-XBlock: https://github.com/edx-solutions/jquery-xblock
-.. _OEP-6 Context-scoped XBlock Fields: http://open-edx-proposals.readthedocs.io/en/latest/oep-0006.html
+.. _OEP-6 Context-scoped XBlock Fields: https://open-edx-proposals.readthedocs.io/en/latest/oep-0006.html
 .. _Pluggable UI hackathon project: https://github.com/edx/edx-platform/pull/14122
 .. _React Native: https://facebook.github.io/react-native/
 .. _Web Components: http://webcomponents.org/

--- a/oeps/oep-0016-bp-adopt-bootstrap.rst
+++ b/oeps/oep-0016-bp-adopt-bootstrap.rst
@@ -256,11 +256,11 @@ variety of sites in the Open edX community.
 .. _Bootstrap Proof-of-Concept PR: https://github.com/edx/edx-platform/pull/14834
 .. _Bootstrap RTL Discovery ticket: https://openedx.atlassian.net/browse/FEDX-352
 .. _Bootstrap 4: https://v4-alpha.getbootstrap.com/
-.. _edX accessibility guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/conventions/accessibility.html
+.. _edX accessibility guidelines: https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/conventions/accessibility.html
 .. _edX Front End Working Group: https://openedx.atlassian.net/wiki/display/FEDX/Front+End+Working+Group
 .. _edX UI Toolkit: http://ui-toolkit.edx.org/
 .. _edX Pattern Library: http://ux.edx.org/
-.. _OEP-11 - Front End Technology Standards: http://open-edx-proposals.readthedocs.io/en/latest/oep-0011.html
+.. _OEP-11 - Front End Technology Standards: https://open-edx-proposals.readthedocs.io/en/latest/oep-0011.html
 .. _Open edX Front End Working Group: https://openedx.atlassian.net/wiki/display/FEDX/Front+End+Working+Group
 .. _postcss: http://postcss.org/
 .. _rtlcss: http://rtlcss.com/

--- a/oeps/oep-0019-bp-developer-documentation.rst
+++ b/oeps/oep-0019-bp-developer-documentation.rst
@@ -121,7 +121,7 @@ ADRs
    * - **Maintenance**
      - Since ADRs are inherently a historical trail of technical decisions, by design, they do not need ongoing maintenance.
 
-.. _`Nygard's post`: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+.. _`Nygard's post`: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
 .. _invaluable technique: https://www.thoughtworks.com/radar/techniques/lightweight-architecture-decision-records
 .. _edx/credentials/docs/decisions: https://github.com/edx/credentials/tree/master/docs/decisions
 

--- a/oeps/oep-0021-proc-deprecation.rst
+++ b/oeps/oep-0021-proc-deprecation.rst
@@ -171,7 +171,7 @@ considers the timing of the next `Open edX named release`_.
 * **Accepted** on Day 14 *(depending on influx of feedback)*
 * **Deprecated/Removing/Removed** - from Day 15 onwards *(depending on resources and technology being removed)*
 
-.. _Open edX named release: http://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
+.. _Open edX named release: https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
 
 Document
 ~~~~~~~~
@@ -292,13 +292,13 @@ Here are some common ways to mark a technology as deprecated:
 
 * Feature toggles - Set the “Expiration Date” as described in OEP-17_.
 
-* Github repo - See `OEP-14 <http://open-edx-proposals.readthedocs.io/en/latest/oep-0014-proc-archive-repos.html>`_
+* Github repo - See `OEP-14 <https://open-edx-proposals.readthedocs.io/en/latest/oep-0014-proc-archive-repos.html>`_
 
 * XBlock - For edx.org specifically, see `Deprecating xBlock for the edX website`_.
 
 .. _warnings.warn: https://docs.python.org/2/library/warnings.html#warnings.warn
-.. _OEP-17: http://open-edx-proposals.readthedocs.io/en/latest/oep-0017-bp-feature-toggles.html
-.. _OEP-14: http://open-edx-proposals.readthedocs.io/en/latest/oep-0014-proc-archive-repos.html
+.. _OEP-17: https://open-edx-proposals.readthedocs.io/en/latest/oep-0017-bp-feature-toggles.html
+.. _OEP-14: https://open-edx-proposals.readthedocs.io/en/latest/oep-0014-proc-archive-repos.html
 .. _Deprecating xBlock for the edX website: https://openedx.atlassian.net/wiki/spaces/ENG/pages/723550424/Deprecating+and+Disabling+an+XBlock+for+the+edX+website
 
 Removing

--- a/oeps/oep-0023-style-customization.rst
+++ b/oeps/oep-0023-style-customization.rst
@@ -195,7 +195,7 @@ References
       https://github.com/edx/edx-platform/blob/master/themes/README.rst
 
 4. Comprehensive Theming
-      http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html
+      https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html
 
 5. edX Pattern Library https://github.com/edx/ux-pattern-library
 

--- a/oeps/oep-0026-arch-realtime-events.rst
+++ b/oeps/oep-0026-arch-realtime-events.rst
@@ -257,7 +257,7 @@ Here are a list of current Open edX frameworks that are related to "eventing" bu
 
 .. _Reactive Manifesto: https://www.reactivemanifesto.org/
 .. _Messaging Patterns for Event-Driven Microservices: https://content.pivotal.io/blog/messaging-patterns-for-event-driven-microservices
-.. _Django Celery: http://docs.celeryproject.org/en/latest/django/
+.. _Django Celery: https://docs.celeryproject.org/en/latest/django/
 
 * **Notifications and messaging framework** - It is also not the intention of this OEP's real-time eventing framework to support real-time messaging to users. The Open edX `Automated Communication Engine (ACE)`_ is a Django library that supports personalized delivery of user-targeted messages. It is a pluggable and modular framework that supports multiple delivery channels with theme-aware and user-language-aware message templates.
 

--- a/oeps/oep-0026/caliper-realtime-events.rst
+++ b/oeps/oep-0026/caliper-realtime-events.rst
@@ -150,7 +150,7 @@ We can provide context in events in the following way:
 Open edX events
 ===============
 
-Currently, the Open edX system supports and maintains events that are sent to tracking logs, as described in `Tracking Log Events <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html>`__.
+Currently, the Open edX system supports and maintains events that are sent to tracking logs, as described in `Tracking Log Events <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html>`__.
 
 Prioritized List of Events
 --------------------------
@@ -159,49 +159,49 @@ For this first iteration, we will focus primarily on the following events:
 
 - **Enrollment events**
 
-  + `edx.course.enrollment.activated <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated>`_.
+  + `edx.course.enrollment.activated <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated>`_.
        Whenever a learner enrolls in a course.
-  + `edx.course.enrollment.deactivated <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated>`_.
+  + `edx.course.enrollment.deactivated <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated>`_.
        Whenever a learner unenrolls from a course.
 
 - **Problem interaction events**
 
-  + `edx.grades.problem.submitted <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/course_team_event_types.html#edx-grades-problem-submitted>`_.
+  + `edx.grades.problem.submitted <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/course_team_event_types.html#edx-grades-problem-submitted>`_.
       Whenever a learner submits any problem.
-  + `problem_check <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#problem-check>`_.
+  + `problem_check <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#problem-check>`_.
        Whenever a learner's answer to a problem is checked.
-  + `showanswer <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#showanswer>`_.
+  + `showanswer <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#showanswer>`_.
        Whenever a learner is shown the answer to a problem.
-  + `edx.problem.hint.demandhint_displayed <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-problem-hint-demandhint-displayed>`_.
+  + `edx.problem.hint.demandhint_displayed <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-problem-hint-demandhint-displayed>`_.
        Whenever a learner requests a hint to a problem.
 
 - **Video events**
 
-  + `edx.video.loaded <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#load-video-edx-video-loaded>`_.
+  + `edx.video.loaded <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#load-video-edx-video-loaded>`_.
        Whenever a learner loads a video.
-  + `edx.video.played <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#play-video-edx-video-played>`_.
+  + `edx.video.played <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#play-video-edx-video-played>`_.
        Whenever a learner plays a video.
-  + `edx.video.stopped <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#stop-video-edx-video-stopped>`_.
+  + `edx.video.stopped <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#stop-video-edx-video-stopped>`_.
        Whenever a learner stops a video.
-  + `edx.video.paused <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#pause-video-edx-video-paused>`_.
+  + `edx.video.paused <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#pause-video-edx-video-paused>`_.
        Whenever a learner pauses a video.
-  + `edx.video.position.changed <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#seek-video-edx-video-position-changed>`_.
+  + `edx.video.position.changed <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#seek-video-edx-video-position-changed>`_.
        Whenever a learner navigates to a different position in a video.
 
 - **Course navigation events**
 
-  + `edx.ui.lms.sequence.outline.selected <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-outline-selected>`_.
+  + `edx.ui.lms.sequence.outline.selected <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-outline-selected>`_.
        Whenever a learner navigates to a subsection in the course.
-  + `edx.ui.lms.sequence.next_selected <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#example-edx-ui-lms-sequence-next-selected-events>`_.
+  + `edx.ui.lms.sequence.next_selected <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#example-edx-ui-lms-sequence-next-selected-events>`_.
        Whenever a learner navigates to the next content in the course.
-  + `edx.ui.lms.sequence.previous_selected <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-sequence-previous-selected>`_.
+  + `edx.ui.lms.sequence.previous_selected <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-sequence-previous-selected>`_.
        Whenever a learner navigates to the previous content in the course.
-  + `edx.ui.lms.sequence.tab_selected <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-sequence-tab-selected>`_.
+  + `edx.ui.lms.sequence.tab_selected <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-sequence-tab-selected>`_.
        Whenever a learner navigates to another unit within a subsection.
-  + `edx.ui.lms.link_clicked <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-link-clicked>`_.
+  + `edx.ui.lms.link_clicked <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-link-clicked>`_.
        Whenever a learner clicks on any link in the course.
 
-.. _Tracking Log Events: http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html
+.. _Tracking Log Events: https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html
 
 Event Field Mapping
 -------------------

--- a/oeps/oep-0026/xapi-realtime-events.rst
+++ b/oeps/oep-0026/xapi-realtime-events.rst
@@ -185,49 +185,49 @@ For this first iteration, we will focus primarily on the following events:
 
 - **Enrollment events**
 
-  + `edx.course.enrollment.activated <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated>`_.
+  + `edx.course.enrollment.activated <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated>`_.
        Whenever a learner enrolls in a course.
-  + `edx.course.enrollment.deactivated <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated>`_.
+  + `edx.course.enrollment.deactivated <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated>`_.
        Whenever a learner unenrolls from a course.
 
 - **Problem interaction events**
 
-  + `edx.grades.problem.submitted <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/course_team_event_types.html#edx-grades-problem-submitted>`_.
+  + `edx.grades.problem.submitted <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/course_team_event_types.html#edx-grades-problem-submitted>`_.
       Whenever a learner submits any problem.
-  + `problem_check <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#problem-check>`_.
+  + `problem_check <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#problem-check>`_.
        Whenever a learner's answer to a problem is checked.
-  + `showanswer <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#showanswer>`_.
+  + `showanswer <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#showanswer>`_.
        Whenever a learner is shown the answer to a problem.
-  + `edx.problem.hint.demandhint_displayed <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-problem-hint-demandhint-displayed>`_.
+  + `edx.problem.hint.demandhint_displayed <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-problem-hint-demandhint-displayed>`_.
        Whenever a learner requests a hint to a problem.
 
 - **Video events**
 
-  + `edx.video.loaded <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#load-video-edx-video-loaded>`_.
+  + `edx.video.loaded <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#load-video-edx-video-loaded>`_.
        Whenever a learner loads a video.
-  + `edx.video.played <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#play-video-edx-video-played>`_.
+  + `edx.video.played <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#play-video-edx-video-played>`_.
        Whenever a learner plays a video.
-  + `edx.video.stopped <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#stop-video-edx-video-stopped>`_.
+  + `edx.video.stopped <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#stop-video-edx-video-stopped>`_.
        Whenever a learner stops a video.
-  + `edx.video.paused <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#pause-video-edx-video-paused>`_.
+  + `edx.video.paused <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#pause-video-edx-video-paused>`_.
        Whenever a learner pauses a video.
-  + `edx.video.position.changed <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#seek-video-edx-video-position-changed>`_.
+  + `edx.video.position.changed <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#seek-video-edx-video-position-changed>`_.
        Whenever a learner navigates to a different position in a video.
 
 - **Course navigation events**
 
-  + `edx.ui.lms.sequence.outline.selected <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-outline-selected>`_.
+  + `edx.ui.lms.sequence.outline.selected <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-outline-selected>`_.
        Whenever a learner navigates to a subsection in the course.
-  + `edx.ui.lms.sequence.next_selected <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#example-edx-ui-lms-sequence-next-selected-events>`_.
+  + `edx.ui.lms.sequence.next_selected <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#example-edx-ui-lms-sequence-next-selected-events>`_.
        Whenever a learner navigates to the next content in the course.
-  + `edx.ui.lms.sequence.previous_selected <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-sequence-previous-selected>`_.
+  + `edx.ui.lms.sequence.previous_selected <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-sequence-previous-selected>`_.
        Whenever a learner navigates to the previous content in the course.
-  + `edx.ui.lms.sequence.tab_selected <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-sequence-tab-selected>`_.
+  + `edx.ui.lms.sequence.tab_selected <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-sequence-tab-selected>`_.
        Whenever a learner navigates to another unit within a subsection.
-  + `edx.ui.lms.link_clicked <http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-link-clicked>`_.
+  + `edx.ui.lms.link_clicked <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-ui-lms-link-clicked>`_.
        Whenever a learner clicks on any link in the course.
 
-.. _Tracking Log Events: http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html
+.. _Tracking Log Events: https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html
 
 Event Field Mapping
 ~~~~~~~~~~~~~~~~~~~

--- a/oeps/oep-templates/adr-based-template.rst
+++ b/oeps/oep-templates/adr-based-template.rst
@@ -58,4 +58,4 @@ References
 List any additional references here that would be useful to the future reader.
 See `Documenting Architecture Decisions`_ for further input.
 
-.. _Documenting Architecture Decisions: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+.. _Documenting Architecture Decisions: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions


### PR DESCRIPTION
This updates a number of URLs to use HTTPS where the server supports
it. It isn't a comprehensive update, just a few domains that show up a
lot in the docs:

- `edx.readthedocs.io`
- `open-edx-proposals.readthedocs.io`
- `github.com`
- `www.django-rest-framework.org`
- `docs.celeryproject.org`
- `http://thinkrelevance.com -> https://cognitect.com` (redirects)