### PR TITLE
doc: Mark DJango app patterns OEP accepted

### DIFF
--- a/oeps/oep-0049-django-app-patterns.rst
+++ b/oeps/oep-0049-django-app-patterns.rst
@@ -17,7 +17,7 @@ OEP-0049: Django App Patterns
    * - Arbiter
      - Jinder Singh
    * - Status
-     - Under Review
+     - Accepted
    * - Type
      - Architecture
    * - Created


### PR DESCRIPTION
This should have been done pre-merge, but was missed.