### PR TITLE
BOM-2555: Fix Requirements Upgrade Github Action

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -35,6 +35,7 @@ jobs:
       - name: make upgrade
         run: |
           cd $GITHUB_WORKSPACE
+          pip install sphinx
           make upgrade
 
       - name: setup testeng-ci


### PR DESCRIPTION
**Issue:** [BOM-2555](https://openedx.atlassian.net/browse/BOM-2555)

## Description
- Requirements upgrade builds were [failing](https://github.com/edx/open-edx-proposals/runs/2662889664?check_suite_focus=true) due to Sphinx not being installed when running `make upgrade` in the script. 

## Solution
- Install `sphinx` before running make upgrade to set the Sphinx build paths for the Make file.

## Test
- Ran the upgrade script with the upgraded `upgrade-python-requirements.yml` and [build](https://github.com/edx/open-edx-proposals/runs/2663098993?check_suite_focus=true) ran successfully and created the [PR](https://github.com/edx/open-edx-proposals/pull/219). The build errored out at the end when tagging the team for review which can be resolved by giving permission to `arbi-bom` team for this repo.