### PR TITLE
docs: Update archive OEP to match current process

### DIFF
--- a/oeps/oep-0002-bp-repo-metadata.rst
+++ b/oeps/oep-0002-bp-repo-metadata.rst
@@ -57,9 +57,6 @@ Each repo will include a file ``openedx.yaml``, with the following keys:
 ``openedx-release``: defined by :doc:`OEP-10 <oep-0010-proc-openedx-releases>` (optional)
     Define this key if your repo is an application or IDA that is part of Open edX releases.  Omit this key if your repo is a library, or is not part of Open edX releases.  See :doc:`OEP-10 <oep-0010-proc-openedx-releases>` for details.
 
-``archived``: boolean (optional)
-    If ``True``, this specifies that this repository is archived and no longer maintained by edX.
-
 Obsolete Keys
 *************
 
@@ -83,6 +80,9 @@ Obsolete Keys
 
 ``nick``:
     This key is obsolete, please remove if found. It was a short-name for this repository, used by reporting tools.
+
+``archived``: boolean (optional)
+    If ``True``, this specifies that this repository is archived and no longer maintained by edX.
 
 
 Tags
@@ -189,6 +189,11 @@ The design of the ``oeps`` dictionary was guided by a couple of use cases:
 
 Change History
 ==============
+
+2021-05-26
+----------
+
+* Move the ``archived`` key to the `Obsolete Keys`_ section.
 
 2020-10-13
 ----------

--- a/oeps/oep-0002-bp-repo-metadata.rst
+++ b/oeps/oep-0002-bp-repo-metadata.rst
@@ -10,7 +10,7 @@ OEP-2: Repository Metadata
    * - Title
      - Repository Metadata
    * - Last Modified
-     - 2021-05-26
+     - 2021-05-27
    * - Authors
      - Calen Pennington, Feanil Patel, Nimisha Asthagiri
    * - Arbiter
@@ -190,7 +190,7 @@ The design of the ``oeps`` dictionary was guided by a couple of use cases:
 Change History
 ==============
 
-2021-05-26
+2021-05-27
 ----------
 
 * Move the ``archived`` key to the `Obsolete Keys`_ section.

--- a/oeps/oep-0002-bp-repo-metadata.rst
+++ b/oeps/oep-0002-bp-repo-metadata.rst
@@ -10,7 +10,7 @@ OEP-2: Repository Metadata
    * - Title
      - Repository Metadata
    * - Last Modified
-     - 2020-08-17
+     - 2021-05-26
    * - Authors
      - Calen Pennington, Feanil Patel, Nimisha Asthagiri
    * - Arbiter

--- a/oeps/oep-0014-proc-archive-repos.rst
+++ b/oeps/oep-0014-proc-archive-repos.rst
@@ -81,8 +81,6 @@ These steps should be followed for all repos within the edX organization(forks i
 
 2. Unless you have the relevant permissions to the work in this step, create an IT help ticket and ask them to do the following:
 
-   - Update the description of the repository to begin with ``[ARCHIVED]`` (TODO: Do we do this or need to???)
-
    - Move the repository to the edx-unsupported organization
 
       - If the repo is not coming from the `edx github org`_ then before moving it, rename it with a prefix of the source org's name. For example the ``notifier`` repo in the ``edx-solutions`` org wolud be renamed to ``edx-solutions-notifier`` before moving.
@@ -209,3 +207,9 @@ Change History
 ----------
 
 * Updated to provide more details around archiving the same fork multiple times.
+
+2021-05-26
+----------
+
+* Removed step of adding ``[ARCHIVED]`` to the repo name. Github's "archive this repo" setting is now available and is a sufficient indicator.
+* Removed ``openedx.yaml`` update steps, since the rest of the archive process is sufficient.

--- a/oeps/oep-0014-proc-archive-repos.rst
+++ b/oeps/oep-0014-proc-archive-repos.rst
@@ -79,7 +79,7 @@ These steps should be followed for all repos within the edX organization(forks i
 
 1. Update the README.rst file in the repository to add a brief note about why the repo is being archived, and what is serving as its replacement (where applicable). This may be as simple as a linking to the appropriate DEPR ticket.
 
-2. Unless you have the relevant permissions to the work in this step, create an IT help ticket and ask them to do the following:
+2. Unless you have the relevant permissions to perform this step, create an IT help ticket and ask them to do the following:
 
    - Archive the repository per `GitHub's archive process`_
 

--- a/oeps/oep-0014-proc-archive-repos.rst
+++ b/oeps/oep-0014-proc-archive-repos.rst
@@ -77,7 +77,7 @@ Archive Steps
 
 These steps should be followed for all repos within the edX organization(forks included). After some experiments with keeping archived repos in the ``edx`` organization, we've learned that having abandoned code show up in searches hinders work to understand the current state of the system and the risk around new work, particularly deprecations and API changes. Thus we decided to move all archived repositories to a separate org.
 
-1. (Recommended) Update the README.rst file in the repository to state that it is archived, using the `README Archive Statement`_ below.
+1. Update the README.rst file in the repository to add a brief note about why the repo is being archived, and what is serving as its replacement (where applicable). This may be as simple as a linking to the appropriate DEPR ticket.
 
 2. Unless you have the relevant permissions to the work in this step, create an IT help ticket and ask them to do the following:
 
@@ -97,15 +97,6 @@ These steps should be followed for all repos within the edX organization(forks i
 .. _GitHub's archive process: https://help.github.com/en/articles/archiving-repositories
 .. _edx github org: https://github.com/edx
 
-
-README Archive Statement
-------------------------
-
-Include this statement in the README.rst file:
-
-    This repository has been archived and is no longer supported—use it at your own risk. This repository may depend on out-of-date libraries with security issues, and security updates will not be provided. Pull requests against this repository will also not be merged.
-
-It is also recommended that you add a brief note about why the repo is being archived, and what it serving as its replacement (where applicable). This may be as simple as a linking to the appropriate DEPR ticket.
 
 Rationale
 =========
@@ -212,4 +203,5 @@ Change History
 ----------
 
 * Removed step of adding ``[ARCHIVED]`` to the repo name. Github's "archive this repo" setting is now available and is a sufficient indicator.
+* Removed step of adding paragraph to README about what archiving means now that we use Github's "archived" marker; the concept of an unmaintained repository and its dangers should be familiar to developers. Keep recommendation to add an explanation of *why* it was archived.
 * Removed ``openedx.yaml`` update steps, since the rest of the archive process is sufficient.

--- a/oeps/oep-0014-proc-archive-repos.rst
+++ b/oeps/oep-0014-proc-archive-repos.rst
@@ -81,11 +81,11 @@ These steps should be followed for all repos within the edX organization(forks i
 
 2. Unless you have the relevant permissions to the work in this step, create an IT help ticket and ask them to do the following:
 
+   - Archive the repository per `GitHub's archive process`_
+
    - Move the repository to the edx-unsupported organization
 
       - If the repo is not coming from the `edx github org`_ then before moving it, rename it with a prefix of the source org's name. For example the ``notifier`` repo in the ``edx-solutions`` org wolud be renamed to ``edx-solutions-notifier`` before moving.
-
-   - Archive the repository per `GitHub's archive process`_
 
 .. note::
     Over the lifetime of Open edX, we may fork the same external open source repository multiple times.  In this case, we may need to archive the fork multiple times as we move between our fork and following upstream.  When this is necessary, if possible un-archive the old fork and update it.  If you've already made a new fork, delete the old copy of the fork before you move the new repo to edx-unsupported.

--- a/oeps/oep-0014-proc-archive-repos.rst
+++ b/oeps/oep-0014-proc-archive-repos.rst
@@ -7,7 +7,7 @@ OEP-14: Archiving edX GitHub Repositories
 +---------------+----------------------------------------------------------+
 | Title         | Archiving edX GitHub Repositories                        |
 +---------------+----------------------------------------------------------+
-| Last Modified | 2017-01-18                                               |
+| Last Modified | 2021-05-25                                               |
 +---------------+----------------------------------------------------------+
 | Author        | Christina Roberts <christina@edx.org>                    |
 |               | Feanil Patel <feanil@edx.org>                            |
@@ -77,19 +77,11 @@ Archive Steps
 
 These steps should be followed for all repos within the edX organization(forks included). After some experiments with keeping archived repos in the ``edx`` organization, we've learned that having abandoned code show up in searches hinders work to understand the current state of the system and the risk around new work, particularly deprecations and API changes. Thus we decided to move all archived repositories to a separate org.
 
-1. Update the README.rst file in the repository to state that it is archived, using the `README Archive Statement`_ below.
+1. (Recommended) Update the README.rst file in the repository to state that it is archived, using the `README Archive Statement`_ below.
 
-2. Update the openedx.yaml file, creating it if necessary:
+2. Unless you have the relevant permissions to the work in this step, create an IT help ticket and ask them to do the following:
 
-   - Add ``archived: True``.
-
-   - Remove the ``openedx-release`` key if it is present.
-
-   - It is not necessary for the openedx.yaml file to define an owner for archived repos.
-
-3. Unless you have the relevant permissions to the work in this step, create an IT help ticket and ask them to do the following:
-
-   - Update the description of the repository to begin with ``[ARCHIVED]``
+   - Update the description of the repository to begin with ``[ARCHIVED]`` (TODO: Do we do this or need to???)
 
    - Move the repository to the edx-unsupported organization
 
@@ -115,6 +107,7 @@ Include this statement in the README.rst file:
 
     This repository has been archived and is no longer supported—use it at your own risk. This repository may depend on out-of-date libraries with security issues, and security updates will not be provided. Pull requests against this repository will also not be merged.
 
+It is also recommended that you add a brief note about why the repo is being archived, and what it serving as its replacement (where applicable). This may be as simple as a linking to the appropriate DEPR ticket.
 
 Rationale
 =========

--- a/oeps/oep-0014-proc-archive-repos.rst
+++ b/oeps/oep-0014-proc-archive-repos.rst
@@ -7,7 +7,7 @@ OEP-14: Archiving edX GitHub Repositories
 +---------------+----------------------------------------------------------+
 | Title         | Archiving edX GitHub Repositories                        |
 +---------------+----------------------------------------------------------+
-| Last Modified | 2021-05-25                                               |
+| Last Modified | 2021-05-27                                               |
 +---------------+----------------------------------------------------------+
 | Author        | Christina Roberts <christina@edx.org>                    |
 |               | Feanil Patel <feanil@edx.org>                            |
@@ -199,7 +199,7 @@ Change History
 
 * Updated to provide more details around archiving the same fork multiple times.
 
-2021-05-26
+2021-05-27
 ----------
 
 * Removed step of adding ``[ARCHIVED]`` to the repo name. Github's "archive this repo" setting is now available and is a sufficient indicator.


### PR DESCRIPTION
When OEP 14 was first written, Github did not yet have a way to mark a
repository as "archived" (adding a banner to the web view of the repo
and makign it read-only). This made it more important for us to mark
the repo via other means, including changing the description, README,
and metadata.

Main changes:

- Mark ``archived`` as obsolete in OEP 2
- Remove requirement of changing repo description (but still request
  explaining *why* it is being archived, what the replacement is, etc.)

Minor changes:

- Put archive step before move step
    - Most valuable step first
    - Easier to forget to do the archiving step if it gets moved first
