### PR TITLE
fix: Treat docs warnings as errors by default. 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the oeps/ directory with Sphinx
 sphinx:
    configuration: oeps/conf.py
+   fail_on_warning: true
 
 python:
    version: 3.8

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS      =
+SPHINXOPTS      = -W
 SPHINXBUILD     = sphinx-build
 SPHINXAUTOBUILD = sphinx-autobuild
 PAPER           =

--- a/README.rst
+++ b/README.rst
@@ -20,5 +20,20 @@ To test locally in a Python virtual env::
 
   # Note: if this fails, you may first need to run: pip install sphinx
   make requirements
-  
+
   make html
+
+Common Warnings
+~~~~~~~~~~~~~~~
+
+Document isn't Included in any toctree
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have some documents that you only reference via ``:doc:`` or ``:ref:`` tags you may get this error.
+If there is no table of contents that the files obviously belong in, an easy way to fix this error is to put the
+documents in a hidden toctree near where they are referenced::
+
+    .. toctree::
+        :hidden:
+
+        path/to/referenced-file.rst

--- a/oeps/conf.py
+++ b/oeps/conf.py
@@ -152,7 +152,7 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/oeps/oep-0001.rst
+++ b/oeps/oep-0001.rst
@@ -85,25 +85,25 @@ Authors
 
 Each OEP must have at least one Author: someone who writes the OEP using the
 style and format described here, shepherds the discussions in the appropriate
-forums, and attempts to build community consensus around the idea.  
+forums, and attempts to build community consensus around the idea.
 
 Arbiter
 -------
 
-Each OEP also has an Arbiter (as described in `Step 1. Request an Arbiter`_). 
+Each OEP also has an Arbiter (as described in `Step 1. Request an Arbiter`_).
 The Arbiter will be chosen by the `edX Architecture Team`_. An Author of an OEP
 cannot concurrently be the Arbiter of that OEP.
 
-The Arbiter will be the person making the final decision on whether the OEP 
-should be Accepted, and as such, the Arbiter should be knowledgeable about 
-the contents of the proposal, and willing to listen to arguments both for 
+The Arbiter will be the person making the final decision on whether the OEP
+should be Accepted, and as such, the Arbiter should be knowledgeable about
+the contents of the proposal, and willing to listen to arguments both for
 and against it by the rest of the community.
 
 The Arbiter is also responsible for helping the Authors move the proposal
 through the OEP process, providing technical and process expertise as needed.
-The Arbiter also assists the Authors in soliciting feedback from the 
+The Arbiter also assists the Authors in soliciting feedback from the
 community on the OEP and moving it towards a final decision (whether that
-decision is Accepted, Rejected, or Deferred). The Arbiter (in discussion with 
+decision is Accepted, Rejected, or Deferred). The Arbiter (in discussion with
 the Authors) can merge an in-progress OEP (if it has reached a stage of relative
 stability) to allow for additional incremental updates.
 
@@ -134,7 +134,7 @@ Submitting an OEP
 Step 1. Request an Arbiter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Request an Arbiter from the `edX Architecture Team`_ by emailing 
+Request an Arbiter from the `edX Architecture Team`_ by emailing
 `arch-team@edx.org`_. This Arbiter will be recorded in the "Arbiter" header on the
 OEP.
 
@@ -145,8 +145,8 @@ Step 2. Create PR for "Draft" OEP
 
 Draft an OEP using one of the `OEP templates`_ and submit as a pull request against
 the `central OEP repository`_. To identify the draft proposal, the Authors should
-check the numbered list of previous OEP pull requests and select the next 
-available number. 
+check the numbered list of previous OEP pull requests and select the next
+available number.
 
 The pull request title should be of the form "OEP-XXXX: <OEP title>", where
 *XXXX* is the OEP number claimed for the included proposal.
@@ -286,8 +286,8 @@ the "Accepted" or "Final" state. However, they may be replaced by subsequent OEP
 (OEPs that are replaced are given the status "Replaced".)
 
 The choice of whether an edit to an OEP should be allowed or whether a new OEP
-should be published is up to the Arbiter of the original OEP, or the `edX 
-Architecture Team`_ if that Arbiter is no longer available. However, as a 
+should be published is up to the Arbiter of the original OEP, or the `edX
+Architecture Team`_ if that Arbiter is no longer available. However, as a
 general guideline, the following updates would not require a replacement OEP.
 
 * Formatting changes.
@@ -346,13 +346,20 @@ to capture the decision(s), as deemed appropriate by the Authors and Arbiter.
 To help guide Authors, here are a few ready-made templates that are available
 for use:
 
-* `PEP-based template`_ based on Python's PEP_ standard.
-* `ADR-based template`_ based on `Architecture Decision Records`_.
-* `External link template`_ for OEPs with mostly external content.
+* :ref:`PEP-based template <pep_based_template>` based on Python's PEP_ standard.
+* :ref:`ADR-based template <adr_based_template>` based on `Architecture Decision Records`_.
+* :ref:`External link template <external_link_template>` for OEPs with mostly external content.
 
-.. _PEP-based template: oep-templates/pep-based-template.rst
-.. _ADR-based template: oep-templates/adr-based-template.rst
-.. _External link template: oep-templates/external-link-template.rst
+..
+  Add a hidden toctree to indicate that these files are referenced from here in the overall
+  table of contents.
+
+.. toctree::
+    :hidden:
+
+    oep-templates/pep-based-template.rst
+    oep-templates/adr-based-template.rst
+    oep-templates/external-link-template.rst
 
 OEP Header Preamble
 -------------------
@@ -395,7 +402,7 @@ described below. All other rows are required.
 +-----------------+-------------------------------------------+
 
 * The **OEP** header is a unique identifier for the OEP, consisting of
-  
+
   * *XXXX* - OEP number claimed for the included proposal.
   * *YYYY* - abbreviated type of the OEP (i.e., "proc", "bp" or "arch").
   * *ZZZZ* - hyphenated brief (< 5 words) title of the proposal.
@@ -492,7 +499,7 @@ Change History
 
   * Reduce steps in submission process
 
-    * Remove the obvious "scope your idea" as an initial step. 
+    * Remove the obvious "scope your idea" as an initial step.
     * Remove "vet your idea" before creating a Draft.
     * Move "request an arbiter" as 1st step in place of vetting and scoping.
 
@@ -504,3 +511,4 @@ Change History
 ----------
 
 * Added a new "Provisional" status.
+

--- a/oeps/oep-0005-arch-containerize-devstack.rst
+++ b/oeps/oep-0005-arch-containerize-devstack.rst
@@ -248,7 +248,7 @@ The following related decisions modify or enhance this OEP, but have not yet bee
 Change History
 ==============
 
-.. _.dockerignore: https://docs.docker.com/engine/reference/builder/#/dockerignore-file
+.. _.dockerignore: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 .. _.gitignore: https://git-scm.com/docs/gitignore
 .. _Django: https://www.djangoproject.com/
 .. _Docker Compose: https://docs.docker.com/compose/overview/

--- a/oeps/oep-0011-bp-FED-technology.rst
+++ b/oeps/oep-0011-bp-FED-technology.rst
@@ -273,7 +273,7 @@ Rejected Alternatives
 .. _edX ESLint Config for ES5: https://github.com/edx/eslint-config-edx/tree/master/packages/eslint-config-edx-es5
 .. _edx Frontend Auth Client: https://github.com/edx/frontend-auth
 .. _enzyme: https://airbnb.io/enzyme/
-.. _ESLint configuration cascading: http://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy
+.. _ESLint configuration cascading: https://eslint.org/docs/user-guide/configuring/configuration-files#cascading-and-hierarchy
 .. _ES2015 Modules: http://www.ecma-international.org/ecma-262/6.0/#sec-imports
 .. _ES2017: https://tc39.github.io/ecma262/
 .. _Fetch: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
@@ -282,7 +282,7 @@ Rejected Alternatives
 .. _Jest: https://jestjs.io/
 .. _JSX: https://facebook.github.io/react/docs/introducing-jsx.html
 .. _oep 18: https://open-edx-proposals.readthedocs.io/en/latest/oep-0018-bp-python-dependencies.html
-.. _package lock: https://docs.npmjs.com/files/package-locks
+.. _package lock: https://docs.npmjs.com/cli/v6/configuring-npm/package-locks
 .. _Polymer: https://www.polymer-project.org/
 .. _React: https://github.com/facebook/react
 .. _React at edX: https://openedx.atlassian.net/wiki/display/FEDX/React

--- a/oeps/oep-0016-bp-adopt-bootstrap.rst
+++ b/oeps/oep-0016-bp-adopt-bootstrap.rst
@@ -259,7 +259,7 @@ variety of sites in the Open edX community.
 .. _edX accessibility guidelines: https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/conventions/accessibility.html
 .. _edX Front End Working Group: https://openedx.atlassian.net/wiki/display/FEDX/Front+End+Working+Group
 .. _edX UI Toolkit: http://ui-toolkit.edx.org/
-.. _edX Pattern Library: http://ux.edx.org/
+.. _edX Pattern Library: https://github.com/edx/ux-pattern-library
 .. _OEP-11 - Front End Technology Standards: https://open-edx-proposals.readthedocs.io/en/latest/oep-0011.html
 .. _Open edX Front End Working Group: https://openedx.atlassian.net/wiki/display/FEDX/Front+End+Working+Group
 .. _postcss: http://postcss.org/

--- a/oeps/oep-0017-bp-feature-toggles.rst
+++ b/oeps/oep-0017-bp-feature-toggles.rst
@@ -44,7 +44,7 @@ Given the many benefits of using feature toggles, edX development teams have bee
 
 Aligning on a common best practice for feature toggling is critical for both the short-term and long-term health of the system. Using different standards, strategies, testing procedures, etc., leads to confusion, production failures, and long-term maintenance issues.
 
-.. _long-term feature branches: https://blog.newrelic.com/2012/11/14/long-running-branches-considered-harmful/
+.. _long-term feature branches: https://newrelic.com/blog/best-practices/long-running-branches-considered-harmful
 
 Use Cases
 ---------

--- a/oeps/oep-0019-bp-developer-documentation.rst
+++ b/oeps/oep-0019-bp-developer-documentation.rst
@@ -53,7 +53,7 @@ Developer documentation is inconsistent and poorly maintained. Documents are als
 Decisions
 *********
 
-* We will use `reStructuredText (rST)`_ as our default documentation format for all developer documentation except for the exceptions outlined here. See the :ref:`Format Rationale` section below for more info on why RST.
+* We will use `reStructuredText (rST)`_ as our default documentation format for all developer documentation except for the exceptions outlined here. See the `Format Rationale`_ section below for more info on why RST.
 
   * Python docstrings that are going to be rendered in an `Open API`_ context should be formatted in Markdown.
 
@@ -71,7 +71,6 @@ Decisions
 
 .. _open-edx-proposals: https://github.com/edx/open-edx-proposals
 .. _edx-developer-docs: https://github.com/edx/edx-developer-docs
-.. _Confluence: https://openedx.atlassian.net/wiki/
 .. _Developer Docs: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/
 .. _Open API: https://www.openapis.org/
 .. _MDX: https://mdxjs.com/
@@ -345,7 +344,7 @@ Rejected alternatives
 Markdown Format
 ===============
 
-We are choosing to not use `Markdown (MD)`_ for documentation. A single format enables consistency, and avoids conversions to rST when requiring additional features. See the `Format`_ section for more details. The `Learning rST`_ section has resources comparing Markdown and rST.
+We are choosing to not use `Markdown (MD)`_ for documentation. A single format enables consistency, and avoids conversions to rST when requiring additional features. See the `Format Rationale`_ section for more details. The `Learning rST`_ section has resources comparing Markdown and rST.
 
 .. _Markdown (MD): https://www.markdownguide.org/
 

--- a/oeps/oep-0026-arch-realtime-events.rst
+++ b/oeps/oep-0026-arch-realtime-events.rst
@@ -127,6 +127,13 @@ Caliper Integration
 
 For details on integrating with Caliper, please see the :ref:`caliper_realtime_events` design document.
 
+.. toctree::
+    :hidden:
+
+    oep-0026/caliper-realtime-events.rst
+    oep-0026/xapi-realtime-events.rst
+
+
 .. _oep-26-user-id:
 
 Anonymized User ID

--- a/oeps/oep-0026/xapi-realtime-events.rst
+++ b/oeps/oep-0026/xapi-realtime-events.rst
@@ -82,7 +82,7 @@ The registry is automatically created from multiple profiles. For now, we will l
 * http://w3id.org
 * http://id.tincanapi.com
 
-If, by any chance, a verb needed by Open edX does not exist in the registry, then we will create a pull request to recommend adding it to the `central GitHub repository of xAPI Profiles`_. 
+If, by any chance, a verb needed by Open edX does not exist in the registry, then we will create a pull request to recommend adding it to the `central GitHub repository of xAPI Profiles`_.
 
 Here is an example of a **Verb** JSON value that we would generate:
 
@@ -117,7 +117,7 @@ Here is an example of an **Object** JSON value that we would generate:
         "id": "https://courses.openedx.org/xblock/block-v1:openedx+origami-folding+1T2018+type@problem+block@abcd",
         "definition": {
             "type": "http://adlnet.gov/expapi/activities/question",
-            "name": { 
+            "name": {
                 "en-US": "Question on mountain fold needed to create an origami crane base",
             }
         }
@@ -239,6 +239,6 @@ Please see the `Open edx xAPI Events`_ document for a detailed view of the mappi
 Implementation Note
 ~~~~~~~~~~~~~~~~~~~
 
-TBD - The development team will assess whether we will use (and start owning) the already implemented (but no longer maintained) `xAPI Python Open Source Library`_. 
+TBD - The development team will assess whether we will use (and start owning) the already implemented (but no longer maintained) `xAPI Python Open Source Library`_.
 
 .. _xAPI Python Open Source Library: https://xapi.com/python-library/

--- a/oeps/oep-0026/xapi-realtime-events.rst
+++ b/oeps/oep-0026/xapi-realtime-events.rst
@@ -78,9 +78,9 @@ The **Verb** in xAPI is a past tensed value, identified by a URI from the `xAPI 
 
 The registry is automatically created from multiple profiles. For now, we will limit ourselves to only URIs prefixed by the following domains, in the following priority order (in case of conflicting names):
 
-* http://adlnet.gov
-* http://w3id.org
-* http://id.tincanapi.com
+* ``http://adlnet.gov``
+* ``http://w3id.org``
+* ``http://id.tincanapi.com``
 
 If, by any chance, a verb needed by Open edX does not exist in the registry, then we will create a pull request to recommend adding it to the `central GitHub repository of xAPI Profiles`_.
 

--- a/oeps/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/oep-0041-arch-async-server-event-messaging.rst
@@ -6,7 +6,7 @@ OEP-41: Asynchronous Server Event Message Format
    :widths: 25 75
 
    * - OEP
-     - :doc:`OEP-41 </oeps/oep-0041-arch-async-server-event-messaging.rst>`
+     - :doc:`OEP-41 <oep-0041-arch-async-server-event-messaging>`
    * - Title
      - Asynchronous Server Event Message Format
    * - Last Modified

--- a/oeps/oep-0045-arch-ops-and-config.rst
+++ b/oeps/oep-0045-arch-ops-and-config.rst
@@ -94,7 +94,7 @@ In order to function as documentation for operators Dockerfiles will be well-com
 * Private or custom install requirements, patches, ARGs, CMD values, etc. should be included via a separately managed Dockerfile built on top of the Open edX image for that codebase.
 
 
-.. _native Dockerfile syntax: https://docs.docker.com/engine/reference/builder/#dockerfile-reference
+.. _native Dockerfile syntax: https://docs.docker.com/engine/reference/builder/
 
 **Docker Images**
 

--- a/oeps/oep-0045-arch-ops-and-config.rst
+++ b/oeps/oep-0045-arch-ops-and-config.rst
@@ -198,3 +198,16 @@ Implementation Strategy
 Discussion of implentation of this OEP will happen in a `separate Pull Request`_ .
 
 .. _separate Pull Request: https://github.com/edx/open-edx-proposals/pull/144
+
+Related Decisions
+=================
+
+The following related decisions modify or enhance this OEP, but have not yet been fully incorporated as updates to this OEP:
+
+.. toctree::
+   :caption: OEP-45 Decisions
+   :maxdepth: 1
+   :glob:
+
+   oep-0045/decisions/*
+

--- a/oeps/oep-0049-django-app-patterns.rst
+++ b/oeps/oep-0049-django-app-patterns.rst
@@ -47,15 +47,15 @@ The common Django files and folders this **won't** set preferences for are:
    :widths: 25 75
 
    * - admin.py
-     - The `additions to the Django admin site <https://docs.djangoproject.com/en/3.1/ref/contrib/admin/>`__ live here
+     - The `additions to the Django admin site <https://docs.djangoproject.com/en/3.2/ref/contrib/admin/>`__ live here
    * - migrations/
-     - The `migrations for the models <https://docs.djangoproject.com/en/3.1/topics/migrations/>`__ live here
+     - The `migrations for the models <https://docs.djangoproject.com/en/3.2/topics/migrations/>`__ live here
    * - management/
-     - The `management commands <https://docs.djangoproject.com/en/3.1/howto/custom-management-command/>`__ live here
+     - The `management commands <https://docs.djangoproject.com/en/3.2/howto/custom-management-commands/>`__ live here
    * - models.py
-     - The `Django ORM models <https://docs.djangoproject.com/en/3.1/topics/db/models/>`__ live here
+     - The `Django ORM models <https://docs.djangoproject.com/en/3.2/topics/db/models/>`__ live here
    * - urls.py
-     - The `URL structure of your app <https://docs.djangoproject.com/en/3.1/topics/http/urls/>`__ is defined here
+     - The `URL structure of your app <https://docs.djangoproject.com/en/3.2/topics/http/urls/>`__ is defined here
 
 More detailed
 

--- a/oeps/oep-templates/adr-based-template.rst
+++ b/oeps/oep-templates/adr-based-template.rst
@@ -1,3 +1,5 @@
+.. _adr_based_template:
+
 ======================
 OEP-XXXX: OEP Template
 ======================
@@ -8,11 +10,14 @@ OEP-XXXX: OEP Template
    :widths: 25 75
 
    * - OEP
-     - :doc:`OEP-XXXX <oep-XXXX-YYYY-ZZZZ>`
+     - Link to the doc in the following format::
 
-       * <XXXX is the next available OEP number>
-       * <YYYY is the abbreviated Type: proc | bp | arch>
-       * <ZZZZ is a brief (< 5 words) version of the title>
+        :doc:`OEP-XXXX <oep-XXXX-YYYY-ZZZZ>`
+
+        * <XXXX is the next available OEP number>
+        * <YYYY is the abbreviated Type: proc | bp | arch>
+        * <ZZZZ is a brief (< 5 words) version of the title>
+
    * - Title
      - <OEP title>
    * - Last Modified

--- a/oeps/oep-templates/external-link-template.rst
+++ b/oeps/oep-templates/external-link-template.rst
@@ -1,3 +1,5 @@
+.. _external_link_template:
+
 ======================
 OEP-XXXX: OEP Template
 ======================
@@ -8,11 +10,14 @@ OEP-XXXX: OEP Template
    :widths: 25 75
 
    * - OEP
-     - :doc:`OEP-XXXX <oep-XXXX-YYYY-ZZZZ>`
+     - Link to the doc in the following format::
 
-       * <XXXX is the next available OEP number>
-       * <YYYY is the abbreviated Type: proc | bp | arch>
-       * <ZZZZ is a brief (< 5 words) version of the title>
+        :doc:`OEP-XXXX <oep-XXXX-YYYY-ZZZZ>`
+
+        * <XXXX is the next available OEP number>
+        * <YYYY is the abbreviated Type: proc | bp | arch>
+        * <ZZZZ is a brief (< 5 words) version of the title>
+
    * - Title
      - <OEP title>
    * - Last Modified

--- a/oeps/oep-templates/pep-based-template.rst
+++ b/oeps/oep-templates/pep-based-template.rst
@@ -1,3 +1,5 @@
+.. _pep_based_template:
+
 ======================
 OEP-XXXX: OEP Template
 ======================
@@ -8,11 +10,14 @@ OEP-XXXX: OEP Template
    :widths: 25 75
 
    * - OEP
-     - :doc:`OEP-XXXX <oep-XXXX-YYYY-ZZZZ>`
+     - Link to the doc in the following format::
 
-       * <XXXX is the next available OEP number>
-       * <YYYY is the abbreviated Type: proc | bp | arch>
-       * <ZZZZ is a brief (< 5 words) version of the title>
+        :doc:`OEP-XXXX <oep-XXXX-YYYY-ZZZZ>`
+
+        * <XXXX is the next available OEP number>
+        * <YYYY is the abbreviated Type: proc | bp | arch>
+        * <ZZZZ is a brief (< 5 words) version of the title>
+
    * - Title
      - <OEP title>
    * - Last Modified


### PR DESCRIPTION
Doc warnings tend to indicate actual broken links, bad targets or
other useful information about how docs are broken.  They should be
treated as errors and fixed before merging new changes to master.

