### PR TITLE
docs: add squash conventional commit prefix (OEP-51)

### DIFF
--- a/oeps/best-practices/oep-0051-bp-conventional-commits.rst
+++ b/oeps/best-practices/oep-0051-bp-conventional-commits.rst
@@ -211,7 +211,7 @@ Tooling
 
 One of the advantages of formalized commit messages is using them as input to tooling and conformance checkers.  We will investigate tooling in the future, and are making no recommendations now.
 
-
+As we trial conformance checking, one open question is whether or not "squash" commits should pass or fail commit linting. See an initial discussion of `linting squash commits in this PR comment thread<https://github.com/edx/open-edx-proposals/pull/254#discussion_r741051683>`__.
 
 Change History
 ==============

--- a/oeps/best-practices/oep-0051-bp-conventional-commits.rst
+++ b/oeps/best-practices/oep-0051-bp-conventional-commits.rst
@@ -216,7 +216,7 @@ As we trial conformance checking, one open question is whether or not "squash" c
 Change History
 ==============
 
-2021-11-01: Squash commits.
+2021-11-01: Add a new ``squash`` commit type.
 
 2021-09-08: Scopes are optional, but unstandardized.
 

--- a/oeps/best-practices/oep-0051-bp-conventional-commits.rst
+++ b/oeps/best-practices/oep-0051-bp-conventional-commits.rst
@@ -211,7 +211,7 @@ Tooling
 
 One of the advantages of formalized commit messages is using them as input to tooling and conformance checkers.  We will investigate tooling in the future, and are making no recommendations now.
 
-As we trial conformance checking, one open question is whether or not "squash" commits should pass or fail commit linting. See an initial discussion of `linting squash commits in this PR comment thread<https://github.com/edx/open-edx-proposals/pull/254#discussion_r741051683>`__.
+As we trial conformance checking, one open question is whether or not "squash" commits should pass or fail commit linting. See an initial discussion of `linting squash commits in this PR comment thread <https://github.com/edx/open-edx-proposals/pull/254#discussion_r741051683>`__.
 
 Change History
 ==============

--- a/oeps/best-practices/oep-0051-bp-conventional-commits.rst
+++ b/oeps/best-practices/oep-0051-bp-conventional-commits.rst
@@ -88,6 +88,8 @@ We use these commit types labels:
 
 * **revert**: undo a previous change. The previous commit message, including the type label, is included.
 
+* **squash**: temporary changes that are intended to be squashed before merged.  Use with caution, because a linter for conventional commits can no longer remind you to squash by failing on missing prefixes.
+
 * **style**: improve the styling of the code.
 
 * **test**: test-only changes. Adds missing tests or corrects existing tests. Tests accompanying other types of changes go into those commits.
@@ -147,6 +149,8 @@ Conventional Commits asks us to categorize changes into a small number of catego
 Choosing the commit type label to use for a commit is important, but it's only the first step.  If you have doubts about which commit type to use, choose the highest-priority type that could apply.  Then write a detailed body explaining the full complexity of your change.
 
 **feat vs fix**: some user-visible changes to features could be classified as "feat" or "fix".  Choose "feat" if the change adds to the set of features.  Choose "fix" if the change affects how a feature behaves.  Yes, this is still subjective.
+
+**squash vs temp vs unknown or missing prefix**: commits that are not intended to be merged could use no prefix or an unknown prefix to communicate to a linter that a PR is not ready to merge. This is nice, but it also forces reviewers to more closely track why a PR is failing throughout the review process. An alternative is to categorize a commit that is *not* intended to be squashed before merge by using "squash". Do *not* use "temp" or "fix" for this use case, since these categories convey a different meaning once merged, and are intended to be merged. Note that if you use "squash" commits, rather than omitting the prefix, you will no longer get reminded to squash through a failed PR.
 
 **Breaking changes to features**: changing how a feature works is not a breaking change.  For example, users are sent to a new experience instead of the old experience. This is not a breaking change.  It should get a "feat" label, but not a "feat!" label.
 
@@ -211,6 +215,8 @@ One of the advantages of formalized commit messages is using them as input to to
 
 Change History
 ==============
+
+2021-11-01: Squash commits.
 
 2021-09-08: Scopes are optional, but unstandardized.
 

--- a/oeps/best-practices/oep-0051-bp-conventional-commits.rst
+++ b/oeps/best-practices/oep-0051-bp-conventional-commits.rst
@@ -150,7 +150,7 @@ Choosing the commit type label to use for a commit is important, but it's only t
 
 **feat vs fix**: some user-visible changes to features could be classified as "feat" or "fix".  Choose "feat" if the change adds to the set of features.  Choose "fix" if the change affects how a feature behaves.  Yes, this is still subjective.
 
-**squash vs temp or fix**: commits that are intended to be squashed before merge should use the "squash" prefix. Although "temp" or "fix" may feel appropriate, they are not meant to be used in this way and convey something meaningful after a PR merges, where "squash" commits are not intended to be merged.
+**squash vs temp or fix**: use "squash" when the *commit* is temporary, and you intend to squash the commit into a larger commit with a different semantic label. Use "temp" when the *change* is temporary, but you intend to merge the commit. Again, use "squash" over "fix" when the *commit* is temporary and is not intended to be merged.
 
 **Breaking changes to features**: changing how a feature works is not a breaking change.  For example, users are sent to a new experience instead of the old experience. This is not a breaking change.  It should get a "feat" label, but not a "feat!" label.
 

--- a/oeps/best-practices/oep-0051-bp-conventional-commits.rst
+++ b/oeps/best-practices/oep-0051-bp-conventional-commits.rst
@@ -88,7 +88,7 @@ We use these commit types labels:
 
 * **revert**: undo a previous change. The previous commit message, including the type label, is included.
 
-* **squash**: temporary changes that are intended to be squashed before merged.
+* **squash**: temporary changes that are intended to be squashed before merging.
 
 * **style**: improve the styling of the code.
 

--- a/oeps/best-practices/oep-0051-bp-conventional-commits.rst
+++ b/oeps/best-practices/oep-0051-bp-conventional-commits.rst
@@ -88,7 +88,7 @@ We use these commit types labels:
 
 * **revert**: undo a previous change. The previous commit message, including the type label, is included.
 
-* **squash**: temporary changes that are intended to be squashed before merged.  Use with caution, because a linter for conventional commits can no longer remind you to squash by failing on missing prefixes.
+* **squash**: temporary changes that are intended to be squashed before merged.
 
 * **style**: improve the styling of the code.
 
@@ -150,7 +150,7 @@ Choosing the commit type label to use for a commit is important, but it's only t
 
 **feat vs fix**: some user-visible changes to features could be classified as "feat" or "fix".  Choose "feat" if the change adds to the set of features.  Choose "fix" if the change affects how a feature behaves.  Yes, this is still subjective.
 
-**squash vs temp vs unknown or missing prefix**: commits that are not intended to be merged could use no prefix or an unknown prefix to communicate to a linter that a PR is not ready to merge. This is nice, but it also forces reviewers to more closely track why a PR is failing throughout the review process. An alternative is to categorize a commit that is *not* intended to be squashed before merge by using "squash". Do *not* use "temp" or "fix" for this use case, since these categories convey a different meaning once merged, and are intended to be merged. Note that if you use "squash" commits, rather than omitting the prefix, you will no longer get reminded to squash through a failed PR.
+**squash vs temp or fix**: commits that are intended to be squashed before merge should use the "squash" prefix. Although "temp" or "fix" may feel appropriate, they are not meant to be used in this way and convey something meaningful after a PR merges, where "squash" commits are not intended to be merged.
 
 **Breaking changes to features**: changing how a feature works is not a breaking change.  For example, users are sent to a new experience instead of the old experience. This is not a breaking change.  It should get a "feat" label, but not a "feat!" label.
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,11 +24,11 @@ jinja2==3.0.2
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
-packaging==21.0
+packaging==21.2
     # via sphinx
 pygments==2.10.0
     # via sphinx
-pyparsing==3.0.1
+pyparsing==2.4.7
     # via packaging
 pytz==2021.3
     # via babel

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,7 +46,7 @@ markupsafe==2.0.1
     # via
     #   -r requirements/base.txt
     #   jinja2
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/base.txt
     #   sphinx
@@ -54,7 +54,7 @@ pygments==2.10.0
     # via
     #   -r requirements/base.txt
     #   sphinx
-pyparsing==3.0.1
+pyparsing==2.4.7
     # via
     #   -r requirements/base.txt
     #   packaging


### PR DESCRIPTION
Add a new "squash" conventional commit prefix as an alternative
to omitting the prefix to designate you intend to squash, or using
another prefix like "temp" or "fix", that wasn't intended for this
purpose.