### PR TITLE
Update README to include GraphViz installation requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,9 @@ View the published list of `Open edX Proposals (OEPs)`_ on ReadTheDocs.
 Testing locally
 ---------------
 
-To test locally in a Python virtual env::
+To test locally in a Python virtual env, you will first need to install `GraphViz <http://graphviz.org/>`_
+On a Mac, this can be done via ``brew install graphviz``; on Ubuntu, use ``sudo apt install graphviz``.
+Next run the following commands::
 
   pip install sphinx  # it may fail for non-obvious reasons without this
   make requirements


### PR DESCRIPTION
I'm working with a fresh environment and found I would repeatedly run into this error:

```
Warning, treated as error:
dot command 'dot' cannot be run (needed for graphviz output), check the graphviz_dot setting
make: *** [html] Error 2
```

You must install GraphViz (because the warning errors out the build). I got assistance on this issue from https://github.com/IQSS/dataverse/pull/7230 and borrowed the language they used because I felt it was clear. 