### PR TITLE
docs: clarify status for Draft and Under Review ADRs/OEPs

### DIFF
--- a/oeps/best-practices/oep-0019-bp-developer-documentation.rst
+++ b/oeps/best-practices/oep-0019-bp-developer-documentation.rst
@@ -168,7 +168,7 @@ A suggested ADR template:
       - **Accepted** *(date)* once it is agreed upon
       - **Superseded** *(date)* with a reference to its replacement if a later ADR changes or reverses the decision
 
-      If an ADR is in Draft, and the intention of the PR is to merge it with a status of Provisional, and not Accepted, you can clarify this in the PR using a status like the following: "Draft (=> Provisional)".
+      If an ADR has Draft status and the PR is under review, you can either use the intended final status (e.g. Provisional, Accepted, etc.), or you can clarify both the current and intended status using something like the following: "Draft (=> Provisional)". Either of these options is especially useful if the merged status is not intended to be Accepted.
 
   Context
   *******

--- a/oeps/processes/oep-0001.rst
+++ b/oeps/processes/oep-0001.rst
@@ -329,9 +329,7 @@ be merged to capture a set of edits, and to make the proposal more visible to
 community comment. From that point, additional pull requests can be opened to
 edit the OEP, until it converges to being either "Accepted" or "Rejected".
 
-If an OEP is in Draft or Under Review, and the intention of the PR is to merge
-it with a status other than Accepted, you can clarify this in the PR using a
-status like the following: "Under Review (=> Provisional)".
+If an OEP has Draft or Under Review status and the PR is under review, you can either use the intended final status (e.g. Provisional, Accepted, etc.), or you can clarify both the current and intended status using something like the following: "Under Review (=> Provisional)". Either of these options is especially useful if the merged status is not intended to be Accepted.
 
 OEP Maintenance
 ---------------


### PR DESCRIPTION
Clarify how to provide a Draft or Under Review status when the OEP PR
is planned to be merged with a status other than Accepted, like Provisional
as an example.