### PR TITLE
fix: Add wiki link for follow up work on OEP 55.

### DIFF
--- a/oeps/processes/oep-0055-proc-project-maintainers.rst
+++ b/oeps/processes/oep-0055-proc-project-maintainers.rst
@@ -28,7 +28,7 @@ OEP-55: Project Maintainers
    * - Resolution
      - <links to any discussions where the final status was decided>
    * - References
-     - `Follow Up Work <https://openedx.atlassian.net/wiki/spaces/COMM/pages/3426844690/Maintainership+Pilot>`
+     - `Follow-up Work <https://openedx.atlassian.net/wiki/spaces/COMM/pages/3426844690/Maintainership+Pilot>`_
 
 .. contents::
    :local:


### PR DESCRIPTION
Per #387 adding a follow up link for the maintainers OEP.