### PR TITLE
docs(OEP-54): Add example threads for CC rights expansion

### DIFF
--- a/oeps/processes/oep-0054-core-contributors.rst
+++ b/oeps/processes/oep-0054-core-contributors.rst
@@ -295,16 +295,23 @@ commit rights generally holds commit rights for only some of the 150+
 
 Expanding a CC's responsibilities should follow the same process as establishing
 a new contributor, although in most cases, the comment period need only be one
-week. In addition, for newly created repositories or similar situations, a
+week. Here's an example of a `simple rights expansion for one existing CC`_.
+In addition, for newly created repositories or similar situations, a
 single forum thread can be used to nominate several existing CCs at once, provided they
 already hold similar responsibilities (e.g. proposing several people who are
-already coding CCs to get commit rights for a new repo).
+already coding CCs to get commit rights for a new repo). Here's an example
+of a `bulk rights expansion for multiple contributors`_ who were already experienced
+coding CCs.
 
 However, in cases where the new responsibilities are greatly different
 from the responsibilities currently held (for example, a coding contributor
 having previously held only backend repo commit rights asking for permission to
 a ``frontend-*`` repo), consider making the comment period the full 2 weeks,
 and use a separate thread for each individual as usual.
+
+
+.. _simple rights expansion for one existing CC: https://discuss.openedx.org/t/coding-cc-rights-expansion-jhony-avella/9638
+.. _bulk rights expansion for multiple contributors: https://discuss.openedx.org/t/cc-rights-expansion-to-enable-raccoongang-to-maintain-frontend-component-cookie-policy-banner/10828
 
 Where Do I Start?
 -----------------


### PR DESCRIPTION
@sarina , do you think it'd be appropriate to add a couple example threads like this to the CC Rights Expansion section of OEP-54? I usually link an example nomination thread any time we need to explain the rights expansion process to someone, so it could save time to just put a couple good ones in the OEP.