### PR TITLE
docs: Add section to OEP-67 on AI Contribution Policy

### DIFF
--- a/oeps/best-practices/oep-0067-bp-tools-and-technology.rst
+++ b/oeps/best-practices/oep-0067-bp-tools-and-technology.rst
@@ -82,6 +82,14 @@ This technology is not specific to frontend or backend code.
    tool should be used to perform Continuous Integration (CI) testing for all Open edX repositories
    that perform any sort of software testing.
 
+#. **Usage of AI for Code Contributions**
+
+   **Rationale**: As AI permeates the developer ecosystem, the Open edX community has decided to welcome
+   the use of AI tools as part of the contribution workflow. Contributors and reviewers should review
+   the project's `AI Contribution Policy`_ before choosing an AI tool or contributing code with it.
+
+.. _AI Contribution Policy: https://github.com/openedx/.github/blob/master/AI_POLICY.md
+
 .. _Frontend Technology Selection:
 
 Frontend Technology Selection
@@ -402,6 +410,12 @@ Consequences
 
 Change History
 **************
+
+2026-05-01
+==========
+
+* Add section on AI contributions
+* `Pull request #787 <https://github.com/openedx/openedx-proposals/pull/787>`_
 
 2026-04-24
 ==========


### PR DESCRIPTION
Elevating the AI Policy as defined in https://github.com/openedx/.github/pull/223

I was scratching my head to figure out the best OEP to add this to. This seemed best but is not a 100% perfect fit imho, happy to take other suggestions.